### PR TITLE
fix some methods on the property list API throw null exception

### DIFF
--- a/src/main/java/sprouts/Vals.java
+++ b/src/main/java/sprouts/Vals.java
@@ -20,7 +20,6 @@ import java.util.stream.StreamSupport;
  * 	<b>Please take a look at the <a href="https://globaltcad.github.io/sprouts/">living sprouts documentation</a>
  * 	where you can browse a large collection of examples demonstrating how to use the API of this class.</b>
  *
- *
  * @param <T> The type of the properties.
  */
 public interface Vals<T> extends Iterable<T>, Observable
@@ -180,13 +179,13 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param value The property to search for in this list.
      * @return The index of the given property in this list, or -1 if not found.
      */
-    default int indexOf( Val<T> value ) { return indexOf(value.get()); }
+    default int indexOf( Val<T> value ) { return indexOf(value.orElseNull()); }
 
     /**
      * @param value The value property to search for.
      * @return True if the given property is in this list.
      */
-    default boolean contains( Val<T> value ) { return contains(value.get()); }
+    default boolean contains( Val<T> value ) { return contains(value.orElseNull()); }
 
     /**
      *  Check for equality between this list of properties and another list of properties.

--- a/src/main/java/sprouts/impl/AbstractVariables.java
+++ b/src/main/java/sprouts/impl/AbstractVariables.java
@@ -257,7 +257,7 @@ public class AbstractVariables<T> implements Vars<T>
             else
                 _variables.add(Var.of(val.get()));
         }
-        if ( vals.size() > 0 ) {
+        if ( vals.isNotEmpty() ) {
             if ( vals.size() > 1 )
                 _triggerAction( Change.ADD, -1, null, null );
             else
@@ -291,7 +291,7 @@ public class AbstractVariables<T> implements Vars<T>
     @Override
     public void sort( Comparator<T> comparator ) {
         if ( _isImmutable ) throw new UnsupportedOperationException("This is an immutable list.");
-        _variables.sort( ( a, b ) -> comparator.compare( a.get(), b.get() ) );
+        _variables.sort( ( a, b ) -> comparator.compare( a.orElseNull(), b.orElseNull() ) );
         _triggerAction( Change.SORT, -1, null, null );
     }
 


### PR DESCRIPTION
fixed some methods on the property list API throw null exception when using nullable 
properties due to the usage of 'get()' instead of 'orElseNull()'.