### PR TITLE
28 introduce null annotations for type parameter cases

### DIFF
--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -229,7 +229,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 *        May not be {@code null}.
 	 * @return the item, if present, otherwise {@code other}
 	 */
-	default T orElse( T other ) {
+	default @NonNull T orElse( @NonNull T other ) {
 		Objects.requireNonNull(other);
 		return isPresent() ? get() : other;
 	}
@@ -361,7 +361,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @throws NullPointerException if the supplying function is {@code null} or
 	 *         produces a {@code null} result
 	 */
-	default Val<T> or( Supplier<? extends Val<? extends T>> supplier ) {
+	default Val<@NonNull T> or( Supplier<? extends Val<? extends @NonNull T>> supplier ) {
 		Objects.requireNonNull(supplier);
 		if ( isPresent() )
 			return this;

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -392,7 +392,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @return A new property either empty (containing null) or containing the result of applying
 	 * 			the mapping function to the item of this property.
 	 */
-	Val<T> map( java.util.function.Function<T, T> mapper );
+	Val<T> map( Function<T, T> mapper );
 
 	/**
 	 *  If the item is present, applies the provided mapping function to it,

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -1,6 +1,5 @@
 package sprouts;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import sprouts.impl.Sprouts;
 
@@ -68,7 +67,7 @@ public interface Val<T> extends Observable
 	 * @param <T> The type of the wrapped item.
 	 * @return A new {@link Val} instance.
 	 */
-	static <T> Val<@Nullable T> ofNullable( Class<T> type, @Nullable T item ) {
+	static <T> Val<T> ofNullable( Class<T> type, @Nullable T item ) {
 		return Sprouts.factory().valOfNullable( type, item );
 	}
 
@@ -82,7 +81,7 @@ public interface Val<T> extends Observable
 	 * @return A new {@link Val} instance.
 	 * @param <T> The type of the wrapped item.
 	 */
-	static <T> Val<@Nullable T> ofNull( Class<T> type ) {
+	static <T> Val<T> ofNull( Class<T> type ) {
 		return Sprouts.factory().valOfNull( type );
 	}
 
@@ -122,7 +121,7 @@ public interface Val<T> extends Observable
 	 * @return A new {@link Val} instance.
 	 * @param <T> The type of the item held by the {@link Val}!
 	 */
-	static <T> Val<@Nullable T> ofNullable( Val<@Nullable T> toBeCopied ) {
+	static <T> Val<T> ofNullable( Val<T> toBeCopied ) {
 		Objects.requireNonNull(toBeCopied);
 		return Sprouts.factory().valOfNullable( toBeCopied );
 	}
@@ -150,11 +149,16 @@ public interface Val<T> extends Observable
 	 *                 the second argument is the item of the second property.
 	 * @return A new {@link Val} instance which is a live view of the two given properties.
 	 * @param <T> The type of the items held by the properties.
+	 * @throws NullPointerException If the combiner function returns a null reference
+	 *                              <b>when it is first called</b>.
+	 * @throws IllegalArgumentException If the types of the two properties are not compatible.
 	 */
 	static <T> Val<T> of( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);
+		if ( first.type() != second.type() )
+			throw new IllegalArgumentException("The types of the two properties are not compatible!");
 		return Sprouts.factory().valOf( first, second, combiner );
 	}
 
@@ -177,11 +181,16 @@ public interface Val<T> extends Observable
 	 *                 the second argument is the item of the second property.
 	 * @return A new {@link Val} instance which is a live view of the two given properties.
 	 * @param <T> The type of the items held by the properties.
+	 * @throws NullPointerException If the combiner function returns a null reference
+	 *                              <b>when it is first called</b>.
+	 * @throws IllegalArgumentException If the types of the two properties are not compatible.
 	 */
-	static <T> Val<@Nullable T> ofNullable( Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner ) {
+	static <T> Val<T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);
+		if ( first.type() != second.type() )
+			throw new IllegalArgumentException("The types of the two properties are not compatible!");
 		return Sprouts.factory().valOfNullable( first, second, combiner );
 	}
 
@@ -209,7 +218,7 @@ public interface Val<T> extends Observable
 	 * @return the item, if present, otherwise {@code other}
 	 */
 	default @Nullable T orElseNullable( @Nullable T other ) {
-		return isPresent() ? get() : other;
+		return orElseNull() != null ? Objects.requireNonNull(orElseNull()) : other;
 	}
 
 	/**
@@ -221,8 +230,8 @@ public interface Val<T> extends Observable
 	 * @return the item, if present, otherwise {@code other}
 	 */
 	default T orElse( T other ) {
-		Objects.requireNonNull(other);
-		return isPresent() ? get() : other;
+		@Nullable T result = orElseNullable( Objects.requireNonNull(other) );
+		return Objects.requireNonNull(result);
 	}
 
 	/**
@@ -231,18 +240,11 @@ public interface Val<T> extends Observable
 	 *
 	 * @param supplier the supplying function that produces an item to be returned
 	 * @return the item, if present, otherwise the result produced by the
-	 * supplying function
-	 * @throws NullPointerException if the supplying function is {@code null} or
-	 *                              produces a {@code null} result
+	 *         supplying function
+	 * @throws NullPointerException if no item is present and the supplying
+	 *         function is {@code null}
 	 */
-	default T orElseGet(Supplier<? extends T> supplier) {
-		if (isPresent())
-			return get();
-
-		T value = supplier.get();
-		Objects.requireNonNull(value);
-		return value;
-	}
+	default T orElseGet( Supplier<? extends T> supplier ) { return this.isPresent() ? orElseThrow() : supplier.get(); }
 
 	/**
 	 * If an item is present, returns the item, otherwise returns
@@ -261,10 +263,10 @@ public interface Val<T> extends Observable
 	 */
 	default T orElseThrow() {
 		// This class is similar to optional, so if the value is null, we throw an exception!
-		@Nullable T value = orElseNull();
-		if ( Objects.isNull(value) )
+		if ( orElseNull() == null )
 			throw new NoSuchElementException("No value present");
-		return value;
+
+		return orElseNull();
 	}
 
 	/**
@@ -321,12 +323,12 @@ public interface Val<T> extends Observable
 	 * otherwise does nothing.
 	 *
 	 * @param action the action to be performed, if an item is present
-	 * @throws NullPointerException The given action is {@code null}
+	 * @throws NullPointerException if item is present and the given action is
+	 *         {@code null}
 	 */
 	default void ifPresent( Consumer<T> action ) {
-		Objects.requireNonNull(action);
 		if ( this.isPresent() )
-			action.accept( get() );
+			action.accept( orElseThrow() );
 	}
 
 	/**
@@ -342,9 +344,9 @@ public interface Val<T> extends Observable
 	 */
 	default void ifPresentOrElse( Consumer<? super T> action, Runnable emptyAction ) {
 		if ( isPresent() )
-			action.accept(get());
-
-		emptyAction.run();
+			action.accept(orElseThrow());
+		else
+			emptyAction.run();
 	}
 
 	/**
@@ -361,13 +363,12 @@ public interface Val<T> extends Observable
 	 */
 	default Val<T> or( Supplier<? extends Val<? extends T>> supplier ) {
 		Objects.requireNonNull(supplier);
-		if ( isPresent() )
-			return this;
-
-		@SuppressWarnings("unchecked")
-		Val<T> r = (Val<T>) supplier.get();
-		Objects.requireNonNull(r);
-		return r;
+		if ( isPresent() ) return this;
+		else {
+			@SuppressWarnings("unchecked")
+			Val<T> r = (Val<T>) supplier.get();
+			return Objects.requireNonNull(r);
+		}
 	}
 
 	/**
@@ -390,7 +391,7 @@ public interface Val<T> extends Observable
 	 * @return A new property either empty (containing null) or containing the result of applying
 	 * 			the mapping function to the item of this property.
 	 */
-	Val<@Nullable T> map( java.util.function.Function<T, T> mapper );
+	Val<T> map( java.util.function.Function<T, T> mapper );
 
 	/**
 	 *  If the item is present, applies the provided mapping function to it,
@@ -412,7 +413,7 @@ public interface Val<T> extends Observable
 	 * 			the mapping function to the item of this property.
 	 * @param <U> The type of the item returned from the mapping function
 	 */
-	<U> Val<@Nullable U> mapTo( Class<U> type, java.util.function.Function<T, U> mapper );
+	<U> Val<U> mapTo( Class<U> type, java.util.function.Function<T, U> mapper );
 
 	/**
 	 * 	Use this to create a live view of this property
@@ -443,7 +444,7 @@ public interface Val<T> extends Observable
 	 * @return A property that is a live view of this property based on the provided mapping function.
 	 * @param <U> The type of the item returned from the mapping function
 	 */
-	<U> Val<@Nullable U> viewAs( Class<U> type, java.util.function.Function<@Nullable T, @Nullable U> mapper );
+	<U> Val<U> viewAs( Class<U> type, java.util.function.Function<T, U> mapper );
 
 	/**
 	 * 	Use this to create a live view of this property
@@ -469,7 +470,7 @@ public interface Val<T> extends Observable
 	 * @param mapper the mapping function to apply to an item, if present
 	 * @return A property that is a live view of this property based on the provided mapping function.
 	 */
-	default Val <@Nullable T> view( java.util.function.Function<@Nullable T, @Nullable T> mapper ) {
+	default Val <T> view( java.util.function.Function<T, T> mapper ) {
 		return viewAs( type(), mapper );
 	}
 
@@ -492,7 +493,7 @@ public interface Val<T> extends Observable
 	 * @param mapper The mapping function to turn the item of this property to a String, if present
 	 * @return A property that is a live view of this property based on the provided mapping function.
 	 */
-	default Val<String> viewAsString( Function<@Nullable T, @Nullable String> mapper ) {
+	default Val<String> viewAsString( Function<T, String> mapper ) {
 		return viewAs( String.class, v -> {
 			try {
 				String stringRef = mapper.apply(v);
@@ -549,7 +550,7 @@ public interface Val<T> extends Observable
 	 * @param mapper the mapping function to turn the item of this property to a Double, if present
 	 * @return A property that is a live view of this property based on the provided mapping function.
 	 */
-	default Val<Double> viewAsDouble( java.util.function.Function<@Nullable T, @Nullable Double> mapper ) {
+	default Val<Double> viewAsDouble( java.util.function.Function<T, Double> mapper ) {
 		return viewAs( Double.class, v -> {
 			try {
 				Double numberRef = mapper.apply(v);
@@ -607,7 +608,7 @@ public interface Val<T> extends Observable
 	 * @param mapper the mapping function to turn the item of this property to a Integer, if present
 	 * @return A property that is a live view of this property based on the provided mapping function.
 	 */
-	default Val<Integer> viewAsInt( java.util.function.Function<@Nullable T, @Nullable Integer> mapper ) {
+	default Val<Integer> viewAsInt( java.util.function.Function<T, Integer> mapper ) {
 		return viewAs( Integer.class, v -> {
 			try {
 				Integer numberRef = mapper.apply(v);
@@ -649,7 +650,7 @@ public interface Val<T> extends Observable
 	 *  which would otherwise be accessed via the {@link #orElseThrow()} method.
 	 *  Calling it should not have any side effects. <br>
 	 *  The string conversion is based on the {@link String#valueOf(Object)} method,
-	 *  so if the item is null, the string "EMPTY" will be returned.
+	 *  so if the item is null, the string "null" will be returned.
 	 *
 	 * @return The {@link String} representation of the item wrapped by an implementation of this interface.
 	 */
@@ -672,7 +673,7 @@ public interface Val<T> extends Observable
 	 * @return The truth value determining if the provided item is equal to the wrapped item.
 	 */
 	default boolean is( @Nullable T otherItem ) {
-		return equals(otherItem, orElseNull());
+		return equals(otherItem, this.orElseNullable(null));
 	}
 
 	/**
@@ -682,9 +683,9 @@ public interface Val<T> extends Observable
 	 * @param other The other property of the same type as is wrapped by this.
 	 * @return The truth value determining if the item of the supplied property is equal to the wrapped item.
 	 */
-	default boolean is( Val<@Nullable T> other ) {
+	default boolean is( Val<T> other ) {
 		Objects.requireNonNull(other);
-		return this.is( other.orElseNull() );
+		return this.is( other.orElseNullable(null) );
 	}
 
 	/**
@@ -694,7 +695,7 @@ public interface Val<T> extends Observable
 	 * @param otherItem The other item of the same type as is wrapped by this.
 	 * @return The truth value determining if the provided item is not equal to the wrapped item.
 	 */
-	default boolean isNot( @Nullable T otherItem ) { return !is(otherItem); }
+	default boolean isNot( @Nullable T otherItem ) { return !this.is(otherItem); }
 
 	/**
 	 *  This method check if the item of the provided property
@@ -704,7 +705,7 @@ public interface Val<T> extends Observable
 	 * @param other The other property of the same type as is wrapped by this.
 	 * @return The truth value determining if the item of the supplied property is not equal to the wrapped item.
 	 */
-	default boolean isNot( Val<@Nullable T> other ) { return !is(other); }
+	default boolean isNot( Val<T> other ) { return !this.is(other); }
 
 	/**
 	 *  This method checks if at least one of the provided items is equal to
@@ -716,12 +717,11 @@ public interface Val<T> extends Observable
 	 * @return The truth value determining if the provided item is equal to the wrapped item.
 	 */
 	@SuppressWarnings("unchecked")
-	default boolean isOneOf( @Nullable T first, @Nullable T second, @Nullable T @NonNull... otherValues ) {
-		if ( is(first) ) return true;
-		if ( is(second) ) return true;
-		if ( otherValues == null) return false;
-        for ( T otherValue : otherValues )
-			if ( is(otherValue) ) return true;
+	default boolean isOneOf( @Nullable T first, @Nullable T second, T... otherValues ) {
+		if ( this.is(first) ) return true;
+		if ( this.is(second) ) return true;
+		for ( T otherValue : otherValues )
+			if ( this.is(otherValue) ) return true;
 		return false;
 	}
 
@@ -735,12 +735,11 @@ public interface Val<T> extends Observable
 	 * @return The truth value determining if the item of the supplied property is equal to the wrapped item.
 	 */
 	@SuppressWarnings("unchecked")
-	default boolean isOneOf( Val<@Nullable T> first, Val<@Nullable T> second, Val<@Nullable T> @NonNull... otherValues ) {
-		if ( is(first) ) return true;
-		if ( is(second) ) return true;
-		if ( otherValues == null) return false;
+	default boolean isOneOf( Val<T> first, Val<T> second, Val<T>... otherValues ) {
+		if ( this.is(first) ) return true;
+		if ( this.is(second) ) return true;
 		for ( Val<T> otherValue : otherValues )
-			if ( is(otherValue) ) return true;
+			if ( this.is(otherValue) ) return true;
 		return false;
 	}
 
@@ -816,7 +815,7 @@ public interface Val<T> extends Observable
 	 * @param action The lambda which will be called whenever the item wrapped by this {@link Var} changes.
 	 * @return The {@link Val} instance itself.
 	 */
-	Val<@Nullable T> onChange( Channel channel, Action<Val<@Nullable T>> action );
+	Val<T> onChange( Channel channel, Action<Val<T>> action );
 
 	/**
 	 *  Triggers all observer lambdas for the given {@link Channel}.
@@ -829,7 +828,7 @@ public interface Val<T> extends Observable
 	 * @param channel The channel from which the item is set.
 	 * @return The {@link Val} instance itself.
 	 */
-	Val<@Nullable T> fireChange( Channel channel );
+	Val<T> fireChange( Channel channel );
 
 	/**
 	 *  A property will only allow null items if it was constructed with a "ofNullable(..)" factory method.

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -121,7 +121,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @return A new {@link Val} instance.
 	 * @param <T> The type of the item held by the {@link Val}!
 	 */
-	static <T> Val<@Nullable T> ofNullable( Val<T> toBeCopied ) {
+	static <T extends @Nullable Object> Val<@Nullable T> ofNullable( Val<T> toBeCopied ) {
 		Objects.requireNonNull(toBeCopied);
 		return Sprouts.factory().valOfNullable( toBeCopied );
 	}

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -185,7 +185,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 *                              <b>when it is first called</b>.
 	 * @throws IllegalArgumentException If the types of the two properties are not compatible.
 	 */
-	static <T extends @Nullable Object> Val<T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	static <T extends @Nullable Object> Val<@Nullable T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -361,7 +361,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @throws NullPointerException if the supplying function is {@code null} or
 	 *         produces a {@code null} result
 	 */
-	default Val<@NonNull T> or( Supplier<? extends Val<? extends @NonNull T>> supplier ) {
+	default Val<T> or( Supplier<? extends Val<? extends T>> supplier ) {
 		Objects.requireNonNull(supplier);
 		if ( isPresent() )
 			return this;

--- a/src/main/java/sprouts/Vals.java
+++ b/src/main/java/sprouts/Vals.java
@@ -1,6 +1,8 @@
 package sprouts;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import sprouts.impl.AbstractVariables;
 import sprouts.impl.Sprouts;
 
 import java.util.*;
@@ -23,8 +25,7 @@ import java.util.stream.StreamSupport;
  *
  * @param <T> The type of the properties.
  */
-public interface Vals<T> extends Iterable<T>, Observable
-{
+public interface Vals<T> extends Iterable<T>, Observable {
 
     /**
      *  Create a new empty {@link Vals} instance.
@@ -33,7 +34,6 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new empty {@link Vals} instance.
      */
     static <T> Vals<T> of( Class<T> type ) {
-        Objects.requireNonNull(type);
         return Sprouts.factory().valsOf( type );
     }
 
@@ -45,9 +45,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> of( Class<T> type, Val<T>... vars ) {
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(vars);
+    static <T> Vals<T> of( Class<T> type, Val<T> @NonNull... vars ) {
         return Sprouts.factory().valsOf( type, vars );
     }
 
@@ -59,9 +57,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> of( Val<T> first, Val<T>... rest ) {
-        Objects.requireNonNull(first);
-        Objects.requireNonNull(rest);
+    static <T> Vals<T> of( Val<T> first, Val<T> @NonNull... rest ) {
         return Sprouts.factory().valsOf( first, rest );
     }
 
@@ -73,7 +69,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> of( T first, T... rest ) {
+    static <T> Vals<T> of( T first, T @NonNull... rest ) {
         return Sprouts.factory().valsOf( first, rest );
     }
 
@@ -86,14 +82,10 @@ public interface Vals<T> extends Iterable<T>, Observable
      *  @return A new {@link Vals} instance.
      */
     static <T> Vals<T> of( Class<T> type, Iterable<Val<T>> properties ) {
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(properties);
         return Sprouts.factory().valsOf( type, properties );
     }
 
     static <T> Vals<T> of( Class<T> type, Vals<T> vals ) {
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(vals);
         return Sprouts.factory().valsOf( type, vals );
     }
 
@@ -103,8 +95,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param <T> The type of the items.
      * @return A new {@link Vals} instance.
      */
-    static <T> Vals<T> ofNullable( Class<T> type ) {
-        Objects.requireNonNull(type);
+    static <T> Vals<@Nullable T> ofNullable( Class<T> type ) {
         return Sprouts.factory().valsOfNullable( type );
     }
 
@@ -116,8 +107,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> ofNullable( Class<T> type, Val<T>... vals ) {
-        Objects.requireNonNull(type);
+    static <T> Vals<@Nullable T> ofNullable( Class<T> type, Val<@Nullable T> @NonNull... vals ) {
         return Sprouts.factory().valsOfNullable( type, vals );
     }
 
@@ -129,8 +119,8 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> ofNullable( Class<T> type, T... items ) {
-        Objects.requireNonNull(type);
+    static <T> Vals<@Nullable T> ofNullable( Class<T> type, @Nullable T @NonNull... items ) {
+        Objects.requireNonNull(items);
         return Sprouts.factory().valsOfNullable( type, items );
     }
 
@@ -142,9 +132,12 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> ofNullable( Val<T> first, Val<T>... rest ) {
-        Objects.requireNonNull(first);
+    static <T> Vals<@Nullable T> ofNullable( Val<T> first, Val<@Nullable T> @NonNull... rest ) {
         return Sprouts.factory().valsOfNullable( first, rest );
+    }
+
+    static <T> Vals<@Nullable T> ofNullable(Class<T> type, Vals<@Nullable T> vals) {
+        return Sprouts.factory().valsOfNullable( type, vals );
     }
 
 
@@ -211,24 +204,27 @@ public interface Vals<T> extends Iterable<T>, Observable
      *  The property at the given index.
      * @param index The index of the property.
      * @return The property at the given index.
+     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    Val<T> at( int index );
+    Val<@Nullable T> at( int index );
 
     /**
-     *  Exposes the first property in the list of properties.
-     *  If there is no first property, an exception will be thrown.
+     * Exposes the first property in the list of properties.
+     * If there is no first property, an exception will be thrown.
      *
      * @return The first property in the list of properties.
+     * @throws NoSuchElementException If the list is empty.
      */
-    Val<T> first();
+    Val<@Nullable T> first();
 
     /**
-     *  Exposes the last property in the list of properties.
-     *  If there is no last property, an exception will be thrown.
+     * Exposes the last property in the list of properties.
+     * If there is no last property, an exception will be thrown.
      *
      * @return The last property in the list of properties.
+     * @throws NoSuchElementException If the list is empty.
      */
-    Val<T> last();
+    Val<@Nullable T> last();
 
     /**
      *  The boolean flag that indicates if the list of properties is empty,
@@ -265,10 +261,9 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param value The value to search for.
      * @return The index of the property that wraps the given value, or -1 if not found.
      */
-    default int indexOf( @Nullable T value )
-    {
+    default int indexOf( @Nullable T value ) {
         int index = 0;
-        for ( T v : this ) {
+        for ( @Nullable T v : this ) {
             if ( Val.equals(v,value) ) return index;
             index++;
         }
@@ -286,7 +281,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param value The property to search for in this list.
      * @return The index of the given property in this list, or -1 if not found.
      */
-    default int indexOf( Val<T> value ) { return indexOf(value.orElseNull()); }
+    default int indexOf( Val<@Nullable T> value ) { return indexOf(value.orElseNull()); }
 
     /**
      *  Check if the value of the supplied property is wrapped by any of the properties in this list.
@@ -295,7 +290,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param value The value property to search for.
      * @return True if the given property is in this list.
      */
-    default boolean contains( Val<T> value ) { return contains(value.orElseNull()); }
+    default boolean contains( Val<@Nullable T> value ) { return contains(value.orElseNull()); }
 
     /**
      *  Check for equality between this list of properties and another list of properties.
@@ -303,7 +298,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param other The other list of properties.
      * @return True if the two lists of properties are equal.
      */
-    default boolean is( Vals<T> other )
+    default boolean is( Vals<@Nullable T> other )
     {
         if ( size() != other.size() ) return false;
         for ( int i = 0; i < size(); i++ )
@@ -318,20 +313,20 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param action The action to perform when the list of properties is shown (which is called when its state changes).
      * @return This list of properties.
      */
-    Vals<T> onChange( Action<ValsDelegate<T>> action );
+    Vals<@Nullable T> onChange( Action<ValsDelegate<@Nullable T>> action );
 
     /**
      *  Similar to {@link Var#fireChange(Channel)} but for a list of properties.
      * @return This list of properties to allow chaining.
      */
-    Vals<T> fireChange();
+    Vals<@Nullable T> fireChange();
 
     /**
      *  Use this for mapping a list of properties to another list of properties.
      * @param mapper The mapper function.
      * @return A new list of properties.
      */
-    Vals<T> map( Function<T,T> mapper );
+    Vals<@Nullable T> map( Function<@Nullable T, @Nullable T> mapper );
 
     /**
      *  Use this for mapping a list of properties to another list of properties.
@@ -340,7 +335,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param <U> The type of the items in the new list of properties.
      * @return A new list of properties.
      */
-    <U> Vals<U> mapTo( Class<U> type, Function<T,U> mapper );
+    <U> Vals<@Nullable U> mapTo( Class<U> type, Function< @Nullable T, @Nullable U> mapper );
 
     /**
      *  Turns this list of properties into a stream of items
@@ -349,7 +344,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      *
      * @return A stream of the items in this list of properties.
      */
-    default Stream<T> stream() { return StreamSupport.stream(spliterator(), false); }
+    default Stream<@Nullable T> stream() { return StreamSupport.stream(spliterator(), false); }
 
     /**
      *  Converts this list of properties to a JDK {@link List} of items
@@ -358,7 +353,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      *
      * @return An immutable list of the items in this list of properties.
      */
-    default List<T> toList() { return Collections.unmodifiableList(stream().collect(Collectors.toList())); }
+    default List<@Nullable T> toList() { return Collections.unmodifiableList(stream().collect(Collectors.toList())); }
 
     /**
      *  Converts this list of properties to a JDK {@link List} of properties
@@ -367,11 +362,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      *
      * @return An immutable {@link List} of properties in this {@link Vals} instance.
      */
-    default List<Val<T>> toValList() {
-        return Collections.unmodifiableList(
-                stream().map( v -> v == null ? Val.ofNullable(type(), null) : Val.of(v) ).collect(Collectors.toList())
-            );
-    }
+    List<Val<@Nullable T>> toValList();
 
     /**
      *  Takes all the items in this list of properties and turns
@@ -379,7 +370,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      *
      * @return An immutable set of the items in this list of properties.
      */
-    default Set<T> toSet() { return Collections.unmodifiableSet(stream().collect(Collectors.toSet())); }
+    default Set<@Nullable T> toSet() { return Collections.unmodifiableSet(stream().collect(Collectors.toSet())); }
 
     /**
      *  A list of properties may be turned into a map of items where the keys are the ids of the properties
@@ -391,10 +382,10 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return An immutable map where the keys are the ids of the properties in this list,
      *         and the values are the items of the properties.
      */
-    default Map<String,T> toMap() {
-        Map<String,T> map = new HashMap<>();
+    default Map<String, @Nullable T> toMap() {
+        Map<String, @Nullable T> map = new HashMap<>();
         for ( int i = 0; i < size(); i++ ) {
-            Val<T> val = at(i);
+            Val<@Nullable T> val = at(i);
             map.put( val.id(), val.orElseNull() );
         }
         return Collections.unmodifiableMap(map);
@@ -410,10 +401,10 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return An immutable map where the keys are the ids of the properties in this list,
      *         and the values are the properties themselves.
      */
-    default Map<String,Val<T>> toValMap() {
-        Map<String,Val<T>> map = new HashMap<>();
+    default Map<String, Val<@Nullable T>> toValMap() {
+        Map<String, Val<@Nullable T>> map = new HashMap<>();
         for ( int i = 0; i < size(); i++ ) {
-            Val<T> val = at(i);
+            Val<@Nullable T> val = at(i);
             map.put( val.id(), val );
         }
         return Collections.unmodifiableMap(map);
@@ -424,21 +415,21 @@ public interface Vals<T> extends Iterable<T>, Observable
      *  @param predicate The predicate to check.
      *  @return True if any of the properties in this list of properties match the given predicate.
      */
-    default boolean any( Predicate<Val<T>> predicate ) { return toValList().stream().anyMatch( predicate ); }
+    default boolean any( Predicate<Val<@Nullable T>> predicate ) { return toValList().stream().anyMatch( predicate ); }
 
     /**
      *  Check if all the properties in this list match the given predicate.
      *  @param predicate The predicate to check.
      *  @return True if all the properties in this list of properties match the given predicate.
      */
-    default boolean all( Predicate<Val<T>> predicate ) { return toValList().stream().allMatch( predicate ); }
+    default boolean all( Predicate<Val<@Nullable T>> predicate ) { return toValList().stream().allMatch( predicate ); }
 
     /**
      *  Check if none of the properties in this list match the given predicate.
      *  @param predicate The predicate to check.
      *  @return True if none of the properties in this list of properties match the given predicate.
      */
-    default boolean none( Predicate<Val<T>> predicate ) { return toValList().stream().noneMatch( predicate ); }
+    default boolean none( Predicate<Val<@Nullable T>> predicate ) { return toValList().stream().noneMatch( predicate ); }
 
     /**
      *  Check if any of the properties in this list is empty.

--- a/src/main/java/sprouts/Vals.java
+++ b/src/main/java/sprouts/Vals.java
@@ -1,8 +1,6 @@
 package sprouts;
 
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import sprouts.impl.AbstractVariables;
 import sprouts.impl.Sprouts;
 
 import java.util.*;
@@ -25,7 +23,8 @@ import java.util.stream.StreamSupport;
  *
  * @param <T> The type of the properties.
  */
-public interface Vals<T> extends Iterable<T>, Observable {
+public interface Vals<T> extends Iterable<T>, Observable
+{
 
     /**
      *  Create a new empty {@link Vals} instance.
@@ -34,6 +33,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return A new empty {@link Vals} instance.
      */
     static <T> Vals<T> of( Class<T> type ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().valsOf( type );
     }
 
@@ -45,7 +45,9 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> of( Class<T> type, Val<T> @NonNull... vars ) {
+    static <T> Vals<T> of( Class<T> type, Val<T>... vars ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(vars);
         return Sprouts.factory().valsOf( type, vars );
     }
 
@@ -57,7 +59,9 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> of( Val<T> first, Val<T> @NonNull... rest ) {
+    static <T> Vals<T> of( Val<T> first, Val<T>... rest ) {
+        Objects.requireNonNull(first);
+        Objects.requireNonNull(rest);
         return Sprouts.factory().valsOf( first, rest );
     }
 
@@ -69,7 +73,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> of( T first, T @NonNull... rest ) {
+    static <T> Vals<T> of( T first, T... rest ) {
         return Sprouts.factory().valsOf( first, rest );
     }
 
@@ -82,10 +86,14 @@ public interface Vals<T> extends Iterable<T>, Observable {
      *  @return A new {@link Vals} instance.
      */
     static <T> Vals<T> of( Class<T> type, Iterable<Val<T>> properties ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(properties);
         return Sprouts.factory().valsOf( type, properties );
     }
 
     static <T> Vals<T> of( Class<T> type, Vals<T> vals ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(vals);
         return Sprouts.factory().valsOf( type, vals );
     }
 
@@ -95,7 +103,8 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @param <T> The type of the items.
      * @return A new {@link Vals} instance.
      */
-    static <T> Vals<@Nullable T> ofNullable( Class<T> type ) {
+    static <T> Vals<T> ofNullable( Class<T> type ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().valsOfNullable( type );
     }
 
@@ -107,7 +116,8 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<@Nullable T> ofNullable( Class<T> type, Val<@Nullable T> @NonNull... vals ) {
+    static <T> Vals<T> ofNullable( Class<T> type, Val<T>... vals ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().valsOfNullable( type, vals );
     }
 
@@ -119,8 +129,8 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<@Nullable T> ofNullable( Class<T> type, @Nullable T @NonNull... items ) {
-        Objects.requireNonNull(items);
+    static <T> Vals<T> ofNullable( Class<T> type, T... items ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().valsOfNullable( type, items );
     }
 
@@ -132,12 +142,9 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<@Nullable T> ofNullable( Val<T> first, Val<@Nullable T> @NonNull... rest ) {
+    static <T> Vals<T> ofNullable( Val<T> first, Val<T>... rest ) {
+        Objects.requireNonNull(first);
         return Sprouts.factory().valsOfNullable( first, rest );
-    }
-
-    static <T> Vals<@Nullable T> ofNullable(Class<T> type, Vals<@Nullable T> vals) {
-        return Sprouts.factory().valsOfNullable( type, vals );
     }
 
 
@@ -204,27 +211,24 @@ public interface Vals<T> extends Iterable<T>, Observable {
      *  The property at the given index.
      * @param index The index of the property.
      * @return The property at the given index.
-     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    Val<@Nullable T> at( int index );
+    Val<T> at( int index );
 
     /**
-     * Exposes the first property in the list of properties.
-     * If there is no first property, an exception will be thrown.
+     *  Exposes the first property in the list of properties.
+     *  If there is no first property, an exception will be thrown.
      *
      * @return The first property in the list of properties.
-     * @throws NoSuchElementException If the list is empty.
      */
-    Val<@Nullable T> first();
+    Val<T> first();
 
     /**
-     * Exposes the last property in the list of properties.
-     * If there is no last property, an exception will be thrown.
+     *  Exposes the last property in the list of properties.
+     *  If there is no last property, an exception will be thrown.
      *
      * @return The last property in the list of properties.
-     * @throws NoSuchElementException If the list is empty.
      */
-    Val<@Nullable T> last();
+    Val<T> last();
 
     /**
      *  The boolean flag that indicates if the list of properties is empty,
@@ -261,9 +265,10 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @param value The value to search for.
      * @return The index of the property that wraps the given value, or -1 if not found.
      */
-    default int indexOf( @Nullable T value ) {
+    default int indexOf( @Nullable T value )
+    {
         int index = 0;
-        for ( @Nullable T v : this ) {
+        for ( T v : this ) {
             if ( Val.equals(v,value) ) return index;
             index++;
         }
@@ -281,7 +286,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @param value The property to search for in this list.
      * @return The index of the given property in this list, or -1 if not found.
      */
-    default int indexOf( Val<@Nullable T> value ) { return indexOf(value.orElseNull()); }
+    default int indexOf( Val<T> value ) { return indexOf(value.orElseNull()); }
 
     /**
      *  Check if the value of the supplied property is wrapped by any of the properties in this list.
@@ -290,7 +295,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @param value The value property to search for.
      * @return True if the given property is in this list.
      */
-    default boolean contains( Val<@Nullable T> value ) { return contains(value.orElseNull()); }
+    default boolean contains( Val<T> value ) { return contains(value.orElseNull()); }
 
     /**
      *  Check for equality between this list of properties and another list of properties.
@@ -298,7 +303,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @param other The other list of properties.
      * @return True if the two lists of properties are equal.
      */
-    default boolean is( Vals<@Nullable T> other )
+    default boolean is( Vals<T> other )
     {
         if ( size() != other.size() ) return false;
         for ( int i = 0; i < size(); i++ )
@@ -313,20 +318,20 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @param action The action to perform when the list of properties is shown (which is called when its state changes).
      * @return This list of properties.
      */
-    Vals<@Nullable T> onChange( Action<ValsDelegate<@Nullable T>> action );
+    Vals<T> onChange( Action<ValsDelegate<T>> action );
 
     /**
      *  Similar to {@link Var#fireChange(Channel)} but for a list of properties.
      * @return This list of properties to allow chaining.
      */
-    Vals<@Nullable T> fireChange();
+    Vals<T> fireChange();
 
     /**
      *  Use this for mapping a list of properties to another list of properties.
      * @param mapper The mapper function.
      * @return A new list of properties.
      */
-    Vals<@Nullable T> map( Function<@Nullable T, @Nullable T> mapper );
+    Vals<T> map( Function<T,T> mapper );
 
     /**
      *  Use this for mapping a list of properties to another list of properties.
@@ -335,7 +340,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @param <U> The type of the items in the new list of properties.
      * @return A new list of properties.
      */
-    <U> Vals<@Nullable U> mapTo( Class<U> type, Function< @Nullable T, @Nullable U> mapper );
+    <U> Vals<U> mapTo( Class<U> type, Function<T,U> mapper );
 
     /**
      *  Turns this list of properties into a stream of items
@@ -344,7 +349,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      *
      * @return A stream of the items in this list of properties.
      */
-    default Stream<@Nullable T> stream() { return StreamSupport.stream(spliterator(), false); }
+    default Stream<T> stream() { return StreamSupport.stream(spliterator(), false); }
 
     /**
      *  Converts this list of properties to a JDK {@link List} of items
@@ -353,7 +358,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      *
      * @return An immutable list of the items in this list of properties.
      */
-    default List<@Nullable T> toList() { return Collections.unmodifiableList(stream().collect(Collectors.toList())); }
+    default List<T> toList() { return Collections.unmodifiableList(stream().collect(Collectors.toList())); }
 
     /**
      *  Converts this list of properties to a JDK {@link List} of properties
@@ -362,7 +367,11 @@ public interface Vals<T> extends Iterable<T>, Observable {
      *
      * @return An immutable {@link List} of properties in this {@link Vals} instance.
      */
-    List<Val<@Nullable T>> toValList();
+    default List<Val<T>> toValList() {
+        return Collections.unmodifiableList(
+                stream().map( v -> v == null ? Val.ofNullable(type(), null) : Val.of(v) ).collect(Collectors.toList())
+            );
+    }
 
     /**
      *  Takes all the items in this list of properties and turns
@@ -370,7 +379,7 @@ public interface Vals<T> extends Iterable<T>, Observable {
      *
      * @return An immutable set of the items in this list of properties.
      */
-    default Set<@Nullable T> toSet() { return Collections.unmodifiableSet(stream().collect(Collectors.toSet())); }
+    default Set<T> toSet() { return Collections.unmodifiableSet(stream().collect(Collectors.toSet())); }
 
     /**
      *  A list of properties may be turned into a map of items where the keys are the ids of the properties
@@ -382,10 +391,10 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return An immutable map where the keys are the ids of the properties in this list,
      *         and the values are the items of the properties.
      */
-    default Map<String, @Nullable T> toMap() {
-        Map<String, @Nullable T> map = new HashMap<>();
+    default Map<String,T> toMap() {
+        Map<String,T> map = new HashMap<>();
         for ( int i = 0; i < size(); i++ ) {
-            Val<@Nullable T> val = at(i);
+            Val<T> val = at(i);
             map.put( val.id(), val.orElseNull() );
         }
         return Collections.unmodifiableMap(map);
@@ -401,10 +410,10 @@ public interface Vals<T> extends Iterable<T>, Observable {
      * @return An immutable map where the keys are the ids of the properties in this list,
      *         and the values are the properties themselves.
      */
-    default Map<String, Val<@Nullable T>> toValMap() {
-        Map<String, Val<@Nullable T>> map = new HashMap<>();
+    default Map<String,Val<T>> toValMap() {
+        Map<String,Val<T>> map = new HashMap<>();
         for ( int i = 0; i < size(); i++ ) {
-            Val<@Nullable T> val = at(i);
+            Val<T> val = at(i);
             map.put( val.id(), val );
         }
         return Collections.unmodifiableMap(map);
@@ -415,21 +424,21 @@ public interface Vals<T> extends Iterable<T>, Observable {
      *  @param predicate The predicate to check.
      *  @return True if any of the properties in this list of properties match the given predicate.
      */
-    default boolean any( Predicate<Val<@Nullable T>> predicate ) { return toValList().stream().anyMatch( predicate ); }
+    default boolean any( Predicate<Val<T>> predicate ) { return toValList().stream().anyMatch( predicate ); }
 
     /**
      *  Check if all the properties in this list match the given predicate.
      *  @param predicate The predicate to check.
      *  @return True if all the properties in this list of properties match the given predicate.
      */
-    default boolean all( Predicate<Val<@Nullable T>> predicate ) { return toValList().stream().allMatch( predicate ); }
+    default boolean all( Predicate<Val<T>> predicate ) { return toValList().stream().allMatch( predicate ); }
 
     /**
      *  Check if none of the properties in this list match the given predicate.
      *  @param predicate The predicate to check.
      *  @return True if none of the properties in this list of properties match the given predicate.
      */
-    default boolean none( Predicate<Val<@Nullable T>> predicate ) { return toValList().stream().noneMatch( predicate ); }
+    default boolean none( Predicate<Val<T>> predicate ) { return toValList().stream().noneMatch( predicate ); }
 
     /**
      *  Check if any of the properties in this list is empty.

--- a/src/main/java/sprouts/Vals.java
+++ b/src/main/java/sprouts/Vals.java
@@ -446,4 +446,14 @@ public interface Vals<T extends @Nullable Object> extends Iterable<T>, Observabl
      *  @return True if any of the properties in this list of properties is empty.
      */
     default boolean anyEmpty() { return any( Val::isEmpty ); }
+
+    /**
+     * A property list will only allow nullable properties if it was constructed with a "ofNullable(..)" factory method.
+     * Otherwise, it will throw an {@link IllegalArgumentException} when trying to set a {@code null} reference.
+     * This flag cannot be changed after the property list has been constructed!
+     *
+     * @return {@code true}, if this property list can contain null, {@code false} otherwise.
+     */
+    boolean allowsNull();
+
 }

--- a/src/main/java/sprouts/Vals.java
+++ b/src/main/java/sprouts/Vals.java
@@ -23,8 +23,7 @@ import java.util.stream.StreamSupport;
  *
  * @param <T> The type of the properties.
  */
-public interface Vals<T> extends Iterable<T>, Observable
-{
+public interface Vals<T extends @Nullable Object> extends Iterable<T>, Observable {
 
     /**
      *  Create a new empty {@link Vals} instance.
@@ -103,7 +102,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param <T> The type of the items.
      * @return A new {@link Vals} instance.
      */
-    static <T> Vals<T> ofNullable( Class<T> type ) {
+    static <T> Vals<@Nullable T> ofNullable( Class<T> type ) {
         Objects.requireNonNull(type);
         return Sprouts.factory().valsOfNullable( type );
     }
@@ -116,7 +115,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> ofNullable( Class<T> type, Val<T>... vals ) {
+    static <T> Vals<@Nullable T> ofNullable( Class<T> type, Val<@Nullable T>... vals ) {
         Objects.requireNonNull(type);
         return Sprouts.factory().valsOfNullable( type, vals );
     }
@@ -129,7 +128,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> ofNullable( Class<T> type, T... items ) {
+    static <T> Vals<@Nullable T> ofNullable( Class<T> type, @Nullable T... items ) {
         Objects.requireNonNull(type);
         return Sprouts.factory().valsOfNullable( type, items );
     }
@@ -142,7 +141,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @return A new {@link Vals} instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vals<T> ofNullable( Val<T> first, Val<T>... rest ) {
+    static <T extends @Nullable Object> Vals<@Nullable T> ofNullable( Val<T> first, Val<T>... rest ) {
         Objects.requireNonNull(first);
         return Sprouts.factory().valsOfNullable( first, rest );
     }
@@ -299,12 +298,14 @@ public interface Vals<T> extends Iterable<T>, Observable
 
     /**
      *  Check for equality between this list of properties and another list of properties.
+     * <p>
+     *  Note: We compare the <strong>values</strong> of the lists, not the nullability or mutability.
+     *  So if the values of the lists are equal, we consider the lists to be equal.
      *
      * @param other The other list of properties.
      * @return True if the two lists of properties are equal.
      */
-    default boolean is( Vals<T> other )
-    {
+    default boolean is( Vals<@Nullable T> other ) {
         if ( size() != other.size() ) return false;
         for ( int i = 0; i < size(); i++ )
             if ( !this.at(i).is(other.at(i)) ) return false;
@@ -340,7 +341,7 @@ public interface Vals<T> extends Iterable<T>, Observable
      * @param <U> The type of the items in the new list of properties.
      * @return A new list of properties.
      */
-    <U> Vals<U> mapTo( Class<U> type, Function<T,U> mapper );
+    <U extends @Nullable Object> Vals<U> mapTo( Class<U> type, Function<T,U> mapper );
 
     /**
      *  Turns this list of properties into a stream of items

--- a/src/main/java/sprouts/Var.java
+++ b/src/main/java/sprouts/Var.java
@@ -200,14 +200,11 @@ public interface Var<T extends @Nullable Object> extends Val<T>
 	 * @return A new property either empty (containing null) or containing the result of applying
 	 * 			the mapping function to the item of this property.
 	 */
-	@Override default Var<@Nullable T> map( Function<T, @Nullable T> mapper ) {
+	@Override default Var<T> map( Function<T, T> mapper ) {
 		if ( !isPresent() )
 			return Var.ofNull( type() );
 
 		T newValue = mapper.apply( get() );
-		if ( newValue == null )
-			return Var.ofNullable( type(), null );
-
 		return allowsNull() ? Var.ofNullable( type(), newValue ) : Var.of( newValue );
 	}
 

--- a/src/main/java/sprouts/Var.java
+++ b/src/main/java/sprouts/Var.java
@@ -86,7 +86,7 @@ public interface Var<T> extends Val<T>
 	 * @param <T> The type of the wrapped item.
 	 * @return A new {@link Var} instance.
 	 */
-	static <T> Var<@Nullable T> ofNullable( Class<T> type, @Nullable T item ) {
+	static <T> Var<T> ofNullable( Class<T> type, @Nullable T item ) {
 		return Sprouts.factory().varOfNullable( type, item );
 	}
 
@@ -102,7 +102,7 @@ public interface Var<T> extends Val<T>
 	 * @return A new {@link Var} instance.
 	 * @param <T> The type of the wrapped item.
 	 */
-	static <T> Var<@Nullable T> ofNull( Class<T> type ) {
+	static <T> Var<T> ofNull( Class<T> type ) {
 		return Sprouts.factory().varOfNull( type );
 	}
 
@@ -119,24 +119,6 @@ public interface Var<T> extends Val<T>
 	 * @throws IllegalArgumentException If the given item is null.
 	 */
 	static <T> Var<T> of( T item ) {
-		return Sprouts.factory().varOf( item );
-	}
-
-	/**
-	 * 	This factory method returns a {@code Var} describing the given non-{@code null}
-	 * 	item similar to {@link Optional#of(Object)}, but specifically
-	 * 	designed to be used for MVVM. <br>
-	 * 	{@link Var} instances returned by this method will report {@code false}
-	 * 	for {@link #allowsNull()}, because <b>the item is guaranteed to be non-null</b>.
-	 *
-	 * @param item The initial item of the property which must not be null.
-	 * @param <T> The type of the item held by the {@link Var}!
-	 * @return A new {@link Var} instance wrapping the given item.
-	 * @throws IllegalArgumentException If the given item is null.
-	 */
-	static <T> Var<T> ofOrThrow( @Nullable T item ) {
-		if (item == null)
-			throw new IllegalArgumentException();
 		return Sprouts.factory().varOf( item );
 	}
 
@@ -165,9 +147,8 @@ public interface Var<T> extends Val<T>
 	 *
 	 * @param newItem The new item which ought to replace the old one.
 	 * @return This very wrapper instance, in order to enable method chaining.
-	 * @throws NullPointerException If the given {@code newItem} is {@code null} and this {@code  Var} is not nullable.
 	 */
-	default Var<@Nullable T> set( @Nullable T newItem ) {
+	default Var<T> set( @Nullable T newItem ) {
 		return this.set(DEFAULT_CHANNEL, newItem);
 	}
 
@@ -180,9 +161,8 @@ public interface Var<T> extends Val<T>
 	 * @param channel The channel from which the item is set.
 	 * @param newItem The new item which ought to replace the old one.
 	 * @return This very wrapper instance, in order to enable method chaining.
-	 * @throws NullPointerException If the given {@code newItem} is {@code null} and this {@code  Var} is not nullable.
 	 */
-	Var<@Nullable T> set( Channel channel, @Nullable T newItem );
+	Var<T> set( Channel channel, @Nullable T newItem );
 
 	/**
 	 *  Use this method to create a new property with an id.
@@ -198,7 +178,7 @@ public interface Var<T> extends Val<T>
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override Var<@Nullable T> onChange( Channel channel, Action<Val<@Nullable T>> action );
+	@Override Var<T> onChange( Channel channel, Action<Val<T>> action );
 
 	/**
 	 *  If the item is present, then this applies the provided mapping function to it,
@@ -220,11 +200,14 @@ public interface Var<T> extends Val<T>
 	 * @return A new property either empty (containing null) or containing the result of applying
 	 * 			the mapping function to the item of this property.
 	 */
-	@Override default Var<@Nullable T> map( java.util.function.Function<T, T> mapper ) {
+	@Override default Var<T> map( java.util.function.Function<T, T> mapper ) {
 		if ( !isPresent() )
-			return Var.ofNull( type() );
+			return Var.ofNullable( type(), null );
 
-		T newValue = mapper.apply( get() );
+		T newValue = mapper.apply( orElseNull() );
+		if ( newValue == null )
+			return Var.ofNullable( type(), null );
+
 		return Var.of( newValue );
 	}
 
@@ -250,9 +233,11 @@ public interface Var<T> extends Val<T>
 	 */
 	@Override default <U> Var<U> mapTo( Class<U> type, java.util.function.Function<T, U> mapper ) {
 		if ( !isPresent() )
-			return Var.ofNull( type );
+			return Var.ofNullable( type, null );
 
-		U newValue = mapper.apply( get() );
+		U newValue = mapper.apply( orElseNull() );
+		if ( newValue == null )
+			return Var.ofNullable( type, null );
 		return Var.of( newValue );
 	}
 

--- a/src/main/java/sprouts/Var.java
+++ b/src/main/java/sprouts/Var.java
@@ -148,7 +148,7 @@ public interface Var<T extends @Nullable Object> extends Val<T>
 	 * @param newItem The new item which ought to replace the old one.
 	 * @return This very wrapper instance, in order to enable method chaining.
 	 */
-	default Var<T> set( @Nullable T newItem ) {
+	default Var<T> set( T newItem ) {
 		return this.set(DEFAULT_CHANNEL, newItem);
 	}
 
@@ -162,7 +162,7 @@ public interface Var<T extends @Nullable Object> extends Val<T>
 	 * @param newItem The new item which ought to replace the old one.
 	 * @return This very wrapper instance, in order to enable method chaining.
 	 */
-	Var<T> set( Channel channel, @Nullable T newItem );
+	Var<T> set( Channel channel, T newItem );
 
 	/**
 	 *  Use this method to create a new property with an id.

--- a/src/main/java/sprouts/Var.java
+++ b/src/main/java/sprouts/Var.java
@@ -65,7 +65,7 @@ import java.util.function.Function;
  *
  * @param <T> The type of the wrapped item.
  */
-public interface Var<T> extends Val<T>
+public interface Var<T extends @Nullable Object> extends Val<T>
 {
 	/**
 	 *  Use this factory method to create a new {@link Var} instance
@@ -86,7 +86,7 @@ public interface Var<T> extends Val<T>
 	 * @param <T> The type of the wrapped item.
 	 * @return A new {@link Var} instance.
 	 */
-	static <T> Var<T> ofNullable( Class<T> type, @Nullable T item ) {
+	static <T> Var<@Nullable T> ofNullable( Class<T> type, @Nullable T item ) {
 		return Sprouts.factory().varOfNullable( type, item );
 	}
 
@@ -102,7 +102,7 @@ public interface Var<T> extends Val<T>
 	 * @return A new {@link Var} instance.
 	 * @param <T> The type of the wrapped item.
 	 */
-	static <T> Var<T> ofNull( Class<T> type ) {
+	static <T> Var<@Nullable T> ofNull( Class<T> type ) {
 		return Sprouts.factory().varOfNull( type );
 	}
 
@@ -200,15 +200,15 @@ public interface Var<T> extends Val<T>
 	 * @return A new property either empty (containing null) or containing the result of applying
 	 * 			the mapping function to the item of this property.
 	 */
-	@Override default Var<T> map( java.util.function.Function<T, T> mapper ) {
+	@Override default Var<@Nullable T> map( Function<T, @Nullable T> mapper ) {
 		if ( !isPresent() )
-			return Var.ofNullable( type(), null );
+			return Var.ofNull( type() );
 
-		T newValue = mapper.apply( orElseNull() );
+		T newValue = mapper.apply( get() );
 		if ( newValue == null )
 			return Var.ofNullable( type(), null );
 
-		return Var.of( newValue );
+		return allowsNull() ? Var.ofNullable( type(), newValue ) : Var.of( newValue );
 	}
 
 	/**
@@ -231,14 +231,15 @@ public interface Var<T> extends Val<T>
 	 * 			the mapping function to the item of this property.
 	 * @param <U> The type of the item returned from the mapping function
 	 */
-	@Override default <U> Var<U> mapTo( Class<U> type, java.util.function.Function<T, U> mapper ) {
+	@Override default <U extends @Nullable Object> Var<@Nullable U> mapTo( Class<U> type, java.util.function.Function<T, U> mapper ) {
 		if ( !isPresent() )
-			return Var.ofNullable( type, null );
+			return Var.ofNull( type );
 
-		U newValue = mapper.apply( orElseNull() );
+		U newValue = mapper.apply( get() );
 		if ( newValue == null )
 			return Var.ofNullable( type, null );
-		return Var.of( newValue );
+
+		return allowsNull() ? Var.ofNullable( type, newValue ) : Var.of( newValue );
 	}
 
 }

--- a/src/main/java/sprouts/Vars.java
+++ b/src/main/java/sprouts/Vars.java
@@ -1,7 +1,5 @@
 package sprouts;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import sprouts.impl.Sprouts;
 
 import java.util.*;
@@ -38,6 +36,7 @@ public interface Vars<T> extends Vals<T>
      */
     @SuppressWarnings("unchecked")
     static <T> Vars<T> of( Class<T> type, Var<T>... vars ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().varsOf( type, vars );
     }
 
@@ -51,6 +50,7 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     static <T> Vars<T> of( Class<T> type ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().varsOf( type );
     }
 
@@ -63,6 +63,7 @@ public interface Vars<T> extends Vals<T>
      */
     @SuppressWarnings("unchecked")
     static <T> Vars<T> of( Var<T> first, Var<T>... rest ) {
+        Objects.requireNonNull(first);
         return Sprouts.factory().varsOf( first, rest );
     }
 
@@ -75,6 +76,7 @@ public interface Vars<T> extends Vals<T>
      */
     @SuppressWarnings("unchecked")
     static <T> Vars<T> of( T first, T... rest ) {
+        Objects.requireNonNull(first);
         return Sprouts.factory().varsOf( first, rest );
     }
 
@@ -88,6 +90,7 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     static <T> Vars<T> of( Class<T> type, Iterable<Var<T>> vars ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().varsOf( type, vars );
     }
 
@@ -102,7 +105,8 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vars<@Nullable T> ofNullable( Class<T> type, Var<@Nullable T>... vars ) {
+    static <T> Vars<T> ofNullable( Class<T> type, Var<T>... vars ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().varsOfNullable( type, vars );
     }
 
@@ -115,7 +119,8 @@ public interface Vars<T> extends Vals<T>
      *  @param <T> The type of the properties.
      *  @return A new Vars instance.
      */
-    static <T> Vars<@Nullable T> ofNullable( Class<T> type ) {
+    static <T> Vars<T> ofNullable( Class<T> type ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().varsOfNullable( type );
     }
 
@@ -130,8 +135,8 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vars<@Nullable T> ofNullable( Class<T> type, @Nullable T @NonNull... values ) {
-        Objects.requireNonNull(values);
+    static <T> Vars<T> ofNullable( Class<T> type, T... values ) {
+        Objects.requireNonNull(type);
         return Sprouts.factory().varsOfNullable( type, values );
     }
 
@@ -143,120 +148,100 @@ public interface Vars<T> extends Vals<T>
      * @return A new Vars instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vars<@Nullable T> ofNullable( Var<@Nullable T> first, Var<@Nullable T>... rest ) {
+    static <T> Vars<T> ofNullable( Var<T> first, Var<T>... rest ) {
+        Objects.requireNonNull(first);
         return Sprouts.factory().varsOfNullable( first, rest );
     }
 
     /** {@inheritDoc} */
-    @Override Var<@Nullable T> at( int index );
+    @Override Var<T> at( int index );
 
     /** {@inheritDoc} */
-    @Override
-    default Var<@Nullable T> first() {
-        if (isEmpty())
-            throw new NoSuchElementException("There is no such property in the list. The list is empty.");
-        return at(0);
-    }
+    @Override default Var<T> first() { return at(0); }
 
     /** {@inheritDoc} */
-    @Override
-    default Var<@Nullable T> last() {
-        if (isEmpty())
-            throw new NoSuchElementException("There is no such property in the list. The list is empty.");
-        return at(size() - 1);
-    }
+    @Override default Var<T> last() { return at(size() - 1); }
 
     /**
-     * Wraps the provided value in a {@link Var} property and adds it to the list.
+     *  Wraps the provided value in a {@link Var} property and adds it to the list.
      *
      * @param value The value to add.
      * @return This list of properties.
-     * @throws IllegalArgumentException If the given item is {@code null} and the list was not created with the
-     *                                  "ofNullable(...)" factory method.
      */
-    Vars<@Nullable T> add(@Nullable T value);
+    default Vars<T> add( T value ) { return add( Var.of(value) ); }
 
     /**
      *  Adds the provided property to the list.
      *
      * @param var The property to add.
      * @return This list of properties.
-     * @throws IllegalArgumentException If the given item is nullable and the list was not created with the
-     *                                  "ofNullable(...)" factory method.
-     * @throws IllegalArgumentException  If given {@code var} is not nullable and the list is nullable.
      */
-    default Vars<@Nullable T> add( Var<@Nullable T> var ) { return addAt( size(), var ); }
+    default Vars<T> add( Var<T> var ) { return addAt( size(), var ); }
 
     /**
      *  Removes the property at the specified index.
      *
      * @param index The index of the property to remove.
      * @return This list of properties.
-     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    Vars<@Nullable T> removeAt( int index );
+    Vars<T> removeAt( int index );
 
     /**
      *  Removes and returns the property at the specified index.
      *
      * @param index The index of the property to remove.
      * @return The removed property.
-     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    default Var<@Nullable T> popAt( int index ) {
+    default Var<T> popAt( int index ) {
         Var<T> var = at(index);
         removeAt(index);
         return var;
     }
 
     /**
-     * Removes the property containing the provided value from the list.
-     * If the value is not found, the list is unchanged.
-     *
-     * @param value The value to remove.
-     * @return This list of properties.
+     *  Removes the property containing the provided value from the list.
+     *  If the value is not found, the list is unchanged.
+     *  @param value The value to remove.
+     *  @return This list of properties.
      */
-    default Vars<@Nullable T> remove( @Nullable T value ) {
-        int index = indexOf(Var.ofNullable(type(), value));
+    default Vars<T> remove( T value ) {
+        int index = indexOf(Var.of(value));
         return index < 0 ? this : removeAt( index );
     }
 
     /**
-     * Removes the property containing the provided value from the list.
-     * If the value is not found, a {@link NoSuchElementException} is thrown.
-     *
-     * @param value The value to remove.
-     * @return This list of properties.
-     * @throws NoSuchElementException If the value is not found.
+     *  Removes the property containing the provided value from the list.
+     *  If the value is not found, a {@link NoSuchElementException} is thrown.
+     *  @param value The value to remove.
+     *  @return This list of properties.
+     * @throws NoSuchElementException if the value is not found.
      */
-    default Vars<@Nullable T> removeOrThrow( @Nullable T value ) {
-        int index = indexOf(Var.ofNullable(type(), value));
+    default Vars<T> removeOrThrow( T value ) {
+        int index = indexOf(Var.of(value));
         if ( index < 0 )
             throw new NoSuchElementException("No such element: " + value);
         return removeAt( index );
     }
 
     /**
-     * Removes the value of the provided property from the list.
-     * If no property with the value is not found, the list is unchanged.
-     *
-     * @param var The property holding the value to remove.
-     * @return This list of properties.
+     *  Removes the provided property from the list.
+     *  If the property is not found, the list is unchanged.
+     *  @param var The property to remove.
+     *  @return This list of properties.
      */
-    default Vars<@Nullable T> remove( Var<@Nullable T> var ) {
+    default Vars<T> remove( Var<T> var ) {
         int index = indexOf(var);
         return index < 0 ? this : removeAt( index );
     }
 
     /**
-     * Removes the value of the provided property from the list.
-     * If no property with the value is not found, a {@link NoSuchElementException} is thrown.
-     *
-     * @param var The property containing the value to remove.
-     * @return This list of properties.
-     * @throws NoSuchElementException If the value of the property is not found.
+     *  Removes the provided property from the list.
+     *  If the property is not found, a {@link NoSuchElementException} is thrown.
+     *  @param var The property to remove.
+     *  @return This list of properties.
+     * @throws NoSuchElementException if the property is not found.
      */
-    default Vars<@Nullable T> removeOrThrow( Var<@Nullable T> var ) {
+    default Vars<T> removeOrThrow( Var<T> var ) {
         int index = indexOf(var);
         if ( index < 0 )
             throw new NoSuchElementException("No such element: " + var);
@@ -268,38 +253,33 @@ public interface Vars<T> extends Vals<T>
      *
      * @return This list of properties.
      */
-    default Vars<@Nullable T> removeFirst() {
-        return size() > 0 ? removeAt(0) : this; }
+    default Vars<T> removeFirst() { return size() > 0 ? removeAt(0) : this; }
 
     /**
-     * Removes the first property from the list and returns it.
+     *  Removes the first property from the list and returns it.
      *
      * @return The removed property.
-     * @throws NoSuchElementException If the list is empty.
      */
-    default Var<@Nullable T> popFirst() {
-        Var<@Nullable T> var = first();
+    default Var<T> popFirst() {
+        Var<T> var = first();
         removeFirst();
         return var;
     }
 
     /**
-     * Removes the last property from the list.
+     *  Removes the last property from the list.
      *
      * @return This list of properties.
      */
-    default Vars<@Nullable T> removeLast() {
-        return size() > 0 ? removeAt(size() - 1) : this;
-    }
+    default Vars<T> removeLast() { return size() > 0 ? removeAt(size() - 1) : this; }
 
     /**
-     * Removes the last property from the list and returns it.
+     *  Removes the last property from the list and returns it.
      *
      * @return The removed property.
-     * @throws NoSuchElementException If the list is empty.
      */
-    default Var<@Nullable T> popLast() {
-        Var<@Nullable T> var = last();
+    default Var<T> popLast() {
+        Var<T> var = last();
         removeLast();
         return var;
     }
@@ -310,7 +290,7 @@ public interface Vars<T> extends Vals<T>
      *  @param count The number of properties to remove.
      *  @return This list of properties.
      */
-    Vars<@Nullable T> removeLast( int count );
+    Vars<T> removeLast( int count );
 
     /**
      *  Removes {@code count} number of properties from the end
@@ -318,14 +298,14 @@ public interface Vars<T> extends Vals<T>
      *  @param count The number of properties to remove.
      *  @return A new list of properties.
      */
-    Vars<@Nullable T> popLast( int count );
+    Vars<T> popLast( int count );
 
     /**
      *  Removes the first {@code count} number of properties from the list.
      *  @param count The number of properties to remove.
      *  @return This list of properties.
      */
-    Vars<@Nullable T> removeFirst( int count );
+    Vars<T> removeFirst( int count );
 
     /**
      *  Removes the first {@code count} number of properties from the list
@@ -333,7 +313,7 @@ public interface Vars<T> extends Vals<T>
      *  @param count The number of properties to remove.
      *  @return A new list of properties.
      */
-    Vars<@Nullable T> popFirst( int count );
+    Vars<T> popFirst( int count );
 
     /**
      *  Removes all properties from the list for which the provided predicate
@@ -342,7 +322,15 @@ public interface Vars<T> extends Vals<T>
      * @param predicate The predicate to test each property.
      * @return This list of properties.
      */
-    Vars<@Nullable T> removeIf(Predicate<Var<@Nullable T>> predicate);
+    default Vars<T> removeIf( Predicate<Var<T>> predicate )
+    {
+        Vars<T> vars = Vars.of(type());
+        for ( int i = size() - 1; i >= 0; i-- )
+            if ( predicate.test(this.at(i)) ) vars.add(this.at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return this;
+    }
 
     /**
      *  Removes all properties from the list for which the provided predicate
@@ -351,7 +339,15 @@ public interface Vars<T> extends Vals<T>
      * @param predicate The predicate to test each property.
      * @return A new list of properties.
      */
-    Vars<@Nullable T> popIf( Predicate<Var<@Nullable T>> predicate );
+    default Vars<T> popIf( Predicate<Var<T>> predicate )
+    {
+        Vars<T> vars = Vars.of(type());
+        for ( int i = size() - 1; i >= 0; i-- )
+            if ( predicate.test(this.at(i)) ) vars.add(this.at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return vars.revert();
+    }
 
     /**
      *  Removes all properties from the list for whose items the provided predicate
@@ -360,7 +356,15 @@ public interface Vars<T> extends Vals<T>
      *  @param predicate The predicate to test each property item.
      *  @return This list of properties.
      */
-    Vars<@Nullable T> removeIfItem( Predicate<@Nullable T> predicate );
+    default Vars<T> removeIfItem( Predicate<T> predicate )
+    {
+        Vars<T> vars = Vars.of(type());
+        for ( int i = size() - 1; i >= 0; i-- )
+            if ( predicate.test(this.at(i).get()) ) vars.add(this.at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return this;
+    }
 
     /**
      *  Removes all properties from the list for whose items the provided predicate
@@ -369,7 +373,15 @@ public interface Vars<T> extends Vals<T>
      *  @param predicate The predicate to test each property item.
      *  @return A new list of properties.
      */
-    Vars<@Nullable T> popIfItem( Predicate<@Nullable T> predicate );
+    default Vars<T> popIfItem( Predicate<T> predicate )
+    {
+        Vars<T> vars = Vars.of(type());
+        for ( int i = size() - 1; i >= 0; i-- )
+            if ( predicate.test(at(i).get()) ) vars.add(at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return vars.revert();
+    }
 
     /**
      *  Removes all properties from the list that are contained in the provided
@@ -377,7 +389,7 @@ public interface Vars<T> extends Vals<T>
      *  @param vars The list of properties to remove.
      *  @return This list of properties.
      */
-    Vars<@Nullable T> removeAll( Vars<@Nullable T> vars );
+    Vars<T> removeAll( Vars<T> vars );
 
     /**
      *  Removes all properties from the list whose items are contained in the provided
@@ -385,101 +397,86 @@ public interface Vars<T> extends Vals<T>
      *  @param items The list of properties to remove.
      *  @return This list of properties.
      */
-    default Vars<@Nullable T> removeAll( @Nullable T @NonNull... items ) {
-        Objects.requireNonNull(items);
-        Vars<@Nullable T> vars = Vars.ofNullable(type());
-        for ( @Nullable T item : items ) vars.add(Var.ofNullable(type(), item));
+    default Vars<T> removeAll( T... items )
+    {
+        Vars<T> vars = Vars.of(type());
+        for ( T item : items ) vars.add(Var.of(item));
         return removeAll(vars);
     }
 
     /**
-     * Wraps the provided value in a {@link Var} property and adds it to the list
-     * at the specified index.
-     *
-     * @param index The index at which to add the property.
-     * @param item  The value to add as a property item.
-     * @return This list of properties.
-     * @throws IllegalArgumentException  If the given item is null and the list was not created with the
-     *                                   "ofNullable(...)" factory method.
-     * @throws IndexOutOfBoundsException If the given index is out of bounds.
+     *  Wraps the provided value in a {@link Var} property and adds it to the list
+     *  at the specified index.
+     *  @param index The index at which to add the property.
+     *  @param item The value to add as a property item.
+     *  @return This list of properties.
      */
-    Vars<@Nullable T> addAt( int index, @Nullable T item );
+    default Vars<T> addAt( int index, T item ) { return addAt(index, Var.of(item)); }
 
     /**
-     * Adds the provided property to the list at the specified index.
-     *
-     * @param index The index at which to add the property.
-     * @param var   The property to add.
-     * @return This list of properties.
-     * @throws IllegalArgumentException  If the given item is nullable and the list was not created with the
-     *                                   "ofNullable(...)" factory method.
-     * @throws IllegalArgumentException  If given {@code var} is not nullable and the list is nullable.
-     * @throws IndexOutOfBoundsException If the given index is out of bounds.
+     *  Adds the provided property to the list at the specified index.
+     *  @param index The index at which to add the property.
+     *  @param var The property to add.
+     *  @return This list of properties.
      */
-    Vars<@Nullable T> addAt( int index, Var<@Nullable T> var );
+    Vars<T> addAt( int index, Var<T> var );
 
     /**
-     * Wraps the provided value in a property and sets it at the specified index
-     * effectively replacing the property at that index.
-     *
-     * @param index The index at which to set the property.
-     * @param item  The value to set.
-     * @return This list of properties.
-     * @throws IllegalArgumentException  If the given item is null and the list was not created with the
-     *                                   "ofNullable(...)" factory method.
-     * @throws IndexOutOfBoundsException If the given index is out of bounds.
+     *  Wraps the provided value in a property and sets it at the specified index
+     *  effectively replacing the property at that index.
+     *  @param index The index at which to set the property.
+     *  @param item The value to set.
+     *  @return This list of properties.
      */
-    Vars<@Nullable T> setAt( int index, @Nullable T item );
+    default Vars<T> setAt( int index, T item ) { return setAt(index, Var.of(item)); }
 
     /**
-     * Places the provided property at the specified index, effectively replacing the property
-     * at that index.
-     *
-     * @param index The index at which to set the property.
-     * @param var   The property to set.
-     * @return This list of properties.
-     * @throws IllegalArgumentException  If given var is nullable and the list was not created with the
-     *                                   "ofNullable(...)" factory method.
-     * @throws IllegalArgumentException  If given {@code var} is not nullable and the list is nullable.
-     * @throws IndexOutOfBoundsException If the given index is out of bounds.
+     *  Places the provided property at the specified index, effectively replacing the property
+     *  at that index.
+     *  @param index The index at which to set the property.
+     *  @param var The property to set.
+     *  @return This list of properties.
      */
-    Vars<@Nullable T> setAt( int index, Var<@Nullable T> var );
+    Vars<T> setAt( int index, Var<T> var );
 
     /**
-     * Wraps each provided item in a property and appends it to this
-     * list of properties.
-     *
-     * @param items The array of values to add as property items.
-     * @return This list of properties.
-     * @throws IllegalArgumentException If one of the given items is null and the list was not created with the
-     *                                  "ofNullable(...)" factory method.
+     *  Wraps each provided item in a property and appends it to this
+     *  list of properties.
+     *  @param items The array of values to add as property items.
+     *  @return This list of properties.
      */
     @SuppressWarnings("unchecked")
-    Vars<@Nullable T> addAll( @Nullable T @NonNull... items );
+    default Vars<T> addAll( T... items )
+    {
+        Vars<T> vars = Vars.of(this.type());
+        for ( T v : items ) vars.add(v);
+        return this.addAll(vars);
+    }
 
     /**
      *  Iterates over the supplied values, and appends
      *  them to this list as properties.
      *  @param items The values to add as property items.
      *  @return This list of properties.
-     *  @throws IllegalArgumentException If one of the given items is null and the list was not created with the
-     *                                  "ofNullable(...)" factory method.
      */
-    Vars<@Nullable T> addAll( Iterable<@Nullable T> items );
+    default Vars<T> addAll( Iterable<T> items )
+    {
+        Vars<T> vars = Vars.of(this.type());
+        for ( T v : items ) vars.add(v);
+        return this.addAll(vars);
+    }
 
     /**
-     * Iterates over the supplied property list, and appends
-     * them to this list.
-     * Note: If the property list {@code vals} is immutable we append a copy of the properties it contains.
-     *
-     * @param vals The properties to add.
-     * @return This list of properties.
-     * @throws IllegalArgumentException If the provided list was created with "ofNullable(...)" and this list was not
-     *                                  created with the "ofNullable(...)" factory method.
-     * @throws IllegalArgumentException If the provided list was not created with "ofNullable(...)" and this list was
-     *                                  created with the "ofNullable(...)" factory method.
+     *  Iterates over the supplied property list, and appends
+     *  them to this list.
+     *  @param vals The properties to add.
+     *  @return This list of properties.
      */
-    Vars<@Nullable T> addAll( Vals<@Nullable T> vals );
+    default Vars<T> addAll( Vals<T> vals )
+    {
+        for ( T v : vals ) add(v);
+        return this;
+    }
 
     /**
      *  The {@link #retainAll(Vars)} method removes all properties from this list
@@ -488,7 +485,7 @@ public interface Vars<T> extends Vals<T>
      *              All other properties will be removed.
      *  @return This list of properties.
      */
-    Vars<@Nullable T> retainAll( Vars<@Nullable T> vars );
+    Vars<T> retainAll( Vars<T> vars );
 
     /**
      *  This method removes all properties from this list
@@ -497,7 +494,12 @@ public interface Vars<T> extends Vals<T>
      *               All other properties will be removed.
      *  @return This list of properties.
      */
-    Vars<@Nullable T> retainAll( @Nullable T @NonNull... items );
+    default Vars<T> retainAll( T... items )
+    {
+        Vars<T> vars = Vars.of(type());
+        for ( T item : items ) vars.add(Var.of(item));
+        return retainAll(vars);
+    }
 
     /**
      *  Removes all properties from this list.
@@ -506,16 +508,41 @@ public interface Vars<T> extends Vals<T>
      *
      * @return This list.
      */
-    Vars<@Nullable T> clear();
+    Vars<T> clear();
 
-    Vals<@Nullable T> toVals();
+    /**
+     *  Use this for mapping a list of properties to another list of properties.
+     */
+    @Override default Vars<T> map( Function<T,T> mapper ) {
+        Objects.requireNonNull(mapper);
+        @SuppressWarnings("unchecked")
+        Var<T>[] vars = new Var[size()];
+        int i = 0;
+        for ( T v : this ) vars[i++] = Var.of( mapper.apply(v) );
+        return Vars.of( type(), vars );
+    }
+
+    /**
+     *  Use this for mapping a list of properties to another list of properties.
+     */
+    @Override default <U> Vars<U> mapTo( Class<U> type, Function<T,U> mapper ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(mapper);
+        @SuppressWarnings("unchecked")
+        Var<U>[] vars = new Var[size()];
+        for ( int i = 0; i < size(); i++ )
+            vars[i] = this.at( i ).mapTo( type, mapper );
+        return Vars.of( type, vars );
+    }
+
+    default Vals<T> toVals() { return Vals.of( type(), this ); }
 
     /**
      *  Use this for sorting the list of properties.
      *
      * @param comparator The comparator to use for sorting.
      */
-    void sort( Comparator<@Nullable T> comparator );
+    void sort( Comparator<T> comparator );
 
     /**
      * Sorts the list of properties using the natural ordering of the
@@ -544,5 +571,5 @@ public interface Vars<T> extends Vals<T>
      *
      * @return This list.
      */
-    Vars<@Nullable T> revert();
+    Vars<T> revert();
 }

--- a/src/main/java/sprouts/Vars.java
+++ b/src/main/java/sprouts/Vars.java
@@ -1,5 +1,7 @@
 package sprouts;
 
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import sprouts.impl.Sprouts;
 
 import java.util.*;
@@ -36,7 +38,6 @@ public interface Vars<T> extends Vals<T>
      */
     @SuppressWarnings("unchecked")
     static <T> Vars<T> of( Class<T> type, Var<T>... vars ) {
-        Objects.requireNonNull(type);
         return Sprouts.factory().varsOf( type, vars );
     }
 
@@ -50,7 +51,6 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     static <T> Vars<T> of( Class<T> type ) {
-        Objects.requireNonNull(type);
         return Sprouts.factory().varsOf( type );
     }
 
@@ -63,7 +63,6 @@ public interface Vars<T> extends Vals<T>
      */
     @SuppressWarnings("unchecked")
     static <T> Vars<T> of( Var<T> first, Var<T>... rest ) {
-        Objects.requireNonNull(first);
         return Sprouts.factory().varsOf( first, rest );
     }
 
@@ -76,7 +75,6 @@ public interface Vars<T> extends Vals<T>
      */
     @SuppressWarnings("unchecked")
     static <T> Vars<T> of( T first, T... rest ) {
-        Objects.requireNonNull(first);
         return Sprouts.factory().varsOf( first, rest );
     }
 
@@ -90,7 +88,6 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     static <T> Vars<T> of( Class<T> type, Iterable<Var<T>> vars ) {
-        Objects.requireNonNull(type);
         return Sprouts.factory().varsOf( type, vars );
     }
 
@@ -105,8 +102,7 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vars<T> ofNullable( Class<T> type, Var<T>... vars ) {
-        Objects.requireNonNull(type);
+    static <T> Vars<@Nullable T> ofNullable( Class<T> type, Var<@Nullable T>... vars ) {
         return Sprouts.factory().varsOfNullable( type, vars );
     }
 
@@ -119,8 +115,7 @@ public interface Vars<T> extends Vals<T>
      *  @param <T> The type of the properties.
      *  @return A new Vars instance.
      */
-    static <T> Vars<T> ofNullable( Class<T> type ) {
-        Objects.requireNonNull(type);
+    static <T> Vars<@Nullable T> ofNullable( Class<T> type ) {
         return Sprouts.factory().varsOfNullable( type );
     }
 
@@ -135,8 +130,8 @@ public interface Vars<T> extends Vals<T>
      *  @return A new Vars instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vars<T> ofNullable( Class<T> type, T... values ) {
-        Objects.requireNonNull(type);
+    static <T> Vars<@Nullable T> ofNullable( Class<T> type, @Nullable T @NonNull... values ) {
+        Objects.requireNonNull(values);
         return Sprouts.factory().varsOfNullable( type, values );
     }
 
@@ -148,100 +143,120 @@ public interface Vars<T> extends Vals<T>
      * @return A new Vars instance.
      */
     @SuppressWarnings("unchecked")
-    static <T> Vars<T> ofNullable( Var<T> first, Var<T>... rest ) {
-        Objects.requireNonNull(first);
+    static <T> Vars<@Nullable T> ofNullable( Var<@Nullable T> first, Var<@Nullable T>... rest ) {
         return Sprouts.factory().varsOfNullable( first, rest );
     }
 
     /** {@inheritDoc} */
-    @Override Var<T> at( int index );
+    @Override Var<@Nullable T> at( int index );
 
     /** {@inheritDoc} */
-    @Override default Var<T> first() { return at(0); }
+    @Override
+    default Var<@Nullable T> first() {
+        if (isEmpty())
+            throw new NoSuchElementException("There is no such property in the list. The list is empty.");
+        return at(0);
+    }
 
     /** {@inheritDoc} */
-    @Override default Var<T> last() { return at(size() - 1); }
+    @Override
+    default Var<@Nullable T> last() {
+        if (isEmpty())
+            throw new NoSuchElementException("There is no such property in the list. The list is empty.");
+        return at(size() - 1);
+    }
 
     /**
-     *  Wraps the provided value in a {@link Var} property and adds it to the list.
+     * Wraps the provided value in a {@link Var} property and adds it to the list.
      *
      * @param value The value to add.
      * @return This list of properties.
+     * @throws IllegalArgumentException If the given item is {@code null} and the list was not created with the
+     *                                  "ofNullable(...)" factory method.
      */
-    default Vars<T> add( T value ) { return add( Var.of(value) ); }
+    Vars<@Nullable T> add(@Nullable T value);
 
     /**
      *  Adds the provided property to the list.
      *
      * @param var The property to add.
      * @return This list of properties.
+     * @throws IllegalArgumentException If the given item is nullable and the list was not created with the
+     *                                  "ofNullable(...)" factory method.
+     * @throws IllegalArgumentException  If given {@code var} is not nullable and the list is nullable.
      */
-    default Vars<T> add( Var<T> var ) { return addAt( size(), var ); }
+    default Vars<@Nullable T> add( Var<@Nullable T> var ) { return addAt( size(), var ); }
 
     /**
      *  Removes the property at the specified index.
      *
      * @param index The index of the property to remove.
      * @return This list of properties.
+     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    Vars<T> removeAt( int index );
+    Vars<@Nullable T> removeAt( int index );
 
     /**
      *  Removes and returns the property at the specified index.
      *
      * @param index The index of the property to remove.
      * @return The removed property.
+     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    default Var<T> popAt( int index ) {
+    default Var<@Nullable T> popAt( int index ) {
         Var<T> var = at(index);
         removeAt(index);
         return var;
     }
 
     /**
-     *  Removes the property containing the provided value from the list.
-     *  If the value is not found, the list is unchanged.
-     *  @param value The value to remove.
-     *  @return This list of properties.
+     * Removes the property containing the provided value from the list.
+     * If the value is not found, the list is unchanged.
+     *
+     * @param value The value to remove.
+     * @return This list of properties.
      */
-    default Vars<T> remove( T value ) {
-        int index = indexOf(Var.of(value));
+    default Vars<@Nullable T> remove( @Nullable T value ) {
+        int index = indexOf(Var.ofNullable(type(), value));
         return index < 0 ? this : removeAt( index );
     }
 
     /**
-     *  Removes the property containing the provided value from the list.
-     *  If the value is not found, a {@link NoSuchElementException} is thrown.
-     *  @param value The value to remove.
-     *  @return This list of properties.
-     * @throws NoSuchElementException if the value is not found.
+     * Removes the property containing the provided value from the list.
+     * If the value is not found, a {@link NoSuchElementException} is thrown.
+     *
+     * @param value The value to remove.
+     * @return This list of properties.
+     * @throws NoSuchElementException If the value is not found.
      */
-    default Vars<T> removeOrThrow( T value ) {
-        int index = indexOf(Var.of(value));
+    default Vars<@Nullable T> removeOrThrow( @Nullable T value ) {
+        int index = indexOf(Var.ofNullable(type(), value));
         if ( index < 0 )
             throw new NoSuchElementException("No such element: " + value);
         return removeAt( index );
     }
 
     /**
-     *  Removes the provided property from the list.
-     *  If the property is not found, the list is unchanged.
-     *  @param var The property to remove.
-     *  @return This list of properties.
+     * Removes the value of the provided property from the list.
+     * If no property with the value is not found, the list is unchanged.
+     *
+     * @param var The property holding the value to remove.
+     * @return This list of properties.
      */
-    default Vars<T> remove( Var<T> var ) {
+    default Vars<@Nullable T> remove( Var<@Nullable T> var ) {
         int index = indexOf(var);
         return index < 0 ? this : removeAt( index );
     }
 
     /**
-     *  Removes the provided property from the list.
-     *  If the property is not found, a {@link NoSuchElementException} is thrown.
-     *  @param var The property to remove.
-     *  @return This list of properties.
-     * @throws NoSuchElementException if the property is not found.
+     * Removes the value of the provided property from the list.
+     * If no property with the value is not found, a {@link NoSuchElementException} is thrown.
+     *
+     * @param var The property containing the value to remove.
+     * @return This list of properties.
+     * @throws NoSuchElementException If the value of the property is not found.
      */
-    default Vars<T> removeOrThrow( Var<T> var ) {
+    default Vars<@Nullable T> removeOrThrow( Var<@Nullable T> var ) {
         int index = indexOf(var);
         if ( index < 0 )
             throw new NoSuchElementException("No such element: " + var);
@@ -253,33 +268,38 @@ public interface Vars<T> extends Vals<T>
      *
      * @return This list of properties.
      */
-    default Vars<T> removeFirst() { return size() > 0 ? removeAt(0) : this; }
+    default Vars<@Nullable T> removeFirst() {
+        return size() > 0 ? removeAt(0) : this; }
 
     /**
-     *  Removes the first property from the list and returns it.
+     * Removes the first property from the list and returns it.
      *
      * @return The removed property.
+     * @throws NoSuchElementException If the list is empty.
      */
-    default Var<T> popFirst() {
-        Var<T> var = first();
+    default Var<@Nullable T> popFirst() {
+        Var<@Nullable T> var = first();
         removeFirst();
         return var;
     }
 
     /**
-     *  Removes the last property from the list.
+     * Removes the last property from the list.
      *
      * @return This list of properties.
      */
-    default Vars<T> removeLast() { return size() > 0 ? removeAt(size() - 1) : this; }
+    default Vars<@Nullable T> removeLast() {
+        return size() > 0 ? removeAt(size() - 1) : this;
+    }
 
     /**
-     *  Removes the last property from the list and returns it.
+     * Removes the last property from the list and returns it.
      *
      * @return The removed property.
+     * @throws NoSuchElementException If the list is empty.
      */
-    default Var<T> popLast() {
-        Var<T> var = last();
+    default Var<@Nullable T> popLast() {
+        Var<@Nullable T> var = last();
         removeLast();
         return var;
     }
@@ -290,7 +310,7 @@ public interface Vars<T> extends Vals<T>
      *  @param count The number of properties to remove.
      *  @return This list of properties.
      */
-    Vars<T> removeLast( int count );
+    Vars<@Nullable T> removeLast( int count );
 
     /**
      *  Removes {@code count} number of properties from the end
@@ -298,14 +318,14 @@ public interface Vars<T> extends Vals<T>
      *  @param count The number of properties to remove.
      *  @return A new list of properties.
      */
-    Vars<T> popLast( int count );
+    Vars<@Nullable T> popLast( int count );
 
     /**
      *  Removes the first {@code count} number of properties from the list.
      *  @param count The number of properties to remove.
      *  @return This list of properties.
      */
-    Vars<T> removeFirst( int count );
+    Vars<@Nullable T> removeFirst( int count );
 
     /**
      *  Removes the first {@code count} number of properties from the list
@@ -313,7 +333,7 @@ public interface Vars<T> extends Vals<T>
      *  @param count The number of properties to remove.
      *  @return A new list of properties.
      */
-    Vars<T> popFirst( int count );
+    Vars<@Nullable T> popFirst( int count );
 
     /**
      *  Removes all properties from the list for which the provided predicate
@@ -322,15 +342,7 @@ public interface Vars<T> extends Vals<T>
      * @param predicate The predicate to test each property.
      * @return This list of properties.
      */
-    default Vars<T> removeIf( Predicate<Var<T>> predicate )
-    {
-        Vars<T> vars = Vars.of(type());
-        for ( int i = size() - 1; i >= 0; i-- )
-            if ( predicate.test(this.at(i)) ) vars.add(this.at(i));
-
-        this.removeAll(vars); // remove from this list at once and trigger events only once!
-        return this;
-    }
+    Vars<@Nullable T> removeIf(Predicate<Var<@Nullable T>> predicate);
 
     /**
      *  Removes all properties from the list for which the provided predicate
@@ -339,15 +351,7 @@ public interface Vars<T> extends Vals<T>
      * @param predicate The predicate to test each property.
      * @return A new list of properties.
      */
-    default Vars<T> popIf( Predicate<Var<T>> predicate )
-    {
-        Vars<T> vars = Vars.of(type());
-        for ( int i = size() - 1; i >= 0; i-- )
-            if ( predicate.test(this.at(i)) ) vars.add(this.at(i));
-
-        this.removeAll(vars); // remove from this list at once and trigger events only once!
-        return vars.revert();
-    }
+    Vars<@Nullable T> popIf( Predicate<Var<@Nullable T>> predicate );
 
     /**
      *  Removes all properties from the list for whose items the provided predicate
@@ -356,15 +360,7 @@ public interface Vars<T> extends Vals<T>
      *  @param predicate The predicate to test each property item.
      *  @return This list of properties.
      */
-    default Vars<T> removeIfItem( Predicate<T> predicate )
-    {
-        Vars<T> vars = Vars.of(type());
-        for ( int i = size() - 1; i >= 0; i-- )
-            if ( predicate.test(this.at(i).get()) ) vars.add(this.at(i));
-
-        this.removeAll(vars); // remove from this list at once and trigger events only once!
-        return this;
-    }
+    Vars<@Nullable T> removeIfItem( Predicate<@Nullable T> predicate );
 
     /**
      *  Removes all properties from the list for whose items the provided predicate
@@ -373,15 +369,7 @@ public interface Vars<T> extends Vals<T>
      *  @param predicate The predicate to test each property item.
      *  @return A new list of properties.
      */
-    default Vars<T> popIfItem( Predicate<T> predicate )
-    {
-        Vars<T> vars = Vars.of(type());
-        for ( int i = size() - 1; i >= 0; i-- )
-            if ( predicate.test(at(i).get()) ) vars.add(at(i));
-
-        this.removeAll(vars); // remove from this list at once and trigger events only once!
-        return vars.revert();
-    }
+    Vars<@Nullable T> popIfItem( Predicate<@Nullable T> predicate );
 
     /**
      *  Removes all properties from the list that are contained in the provided
@@ -389,7 +377,7 @@ public interface Vars<T> extends Vals<T>
      *  @param vars The list of properties to remove.
      *  @return This list of properties.
      */
-    Vars<T> removeAll( Vars<T> vars );
+    Vars<@Nullable T> removeAll( Vars<@Nullable T> vars );
 
     /**
      *  Removes all properties from the list whose items are contained in the provided
@@ -397,86 +385,101 @@ public interface Vars<T> extends Vals<T>
      *  @param items The list of properties to remove.
      *  @return This list of properties.
      */
-    default Vars<T> removeAll( T... items )
-    {
-        Vars<T> vars = Vars.of(type());
-        for ( T item : items ) vars.add(Var.of(item));
+    default Vars<@Nullable T> removeAll( @Nullable T @NonNull... items ) {
+        Objects.requireNonNull(items);
+        Vars<@Nullable T> vars = Vars.ofNullable(type());
+        for ( @Nullable T item : items ) vars.add(Var.ofNullable(type(), item));
         return removeAll(vars);
     }
 
     /**
-     *  Wraps the provided value in a {@link Var} property and adds it to the list
-     *  at the specified index.
-     *  @param index The index at which to add the property.
-     *  @param item The value to add as a property item.
-     *  @return This list of properties.
+     * Wraps the provided value in a {@link Var} property and adds it to the list
+     * at the specified index.
+     *
+     * @param index The index at which to add the property.
+     * @param item  The value to add as a property item.
+     * @return This list of properties.
+     * @throws IllegalArgumentException  If the given item is null and the list was not created with the
+     *                                   "ofNullable(...)" factory method.
+     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    default Vars<T> addAt( int index, T item ) { return addAt(index, Var.of(item)); }
+    Vars<@Nullable T> addAt( int index, @Nullable T item );
 
     /**
-     *  Adds the provided property to the list at the specified index.
-     *  @param index The index at which to add the property.
-     *  @param var The property to add.
-     *  @return This list of properties.
+     * Adds the provided property to the list at the specified index.
+     *
+     * @param index The index at which to add the property.
+     * @param var   The property to add.
+     * @return This list of properties.
+     * @throws IllegalArgumentException  If the given item is nullable and the list was not created with the
+     *                                   "ofNullable(...)" factory method.
+     * @throws IllegalArgumentException  If given {@code var} is not nullable and the list is nullable.
+     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    Vars<T> addAt( int index, Var<T> var );
+    Vars<@Nullable T> addAt( int index, Var<@Nullable T> var );
 
     /**
-     *  Wraps the provided value in a property and sets it at the specified index
-     *  effectively replacing the property at that index.
-     *  @param index The index at which to set the property.
-     *  @param item The value to set.
-     *  @return This list of properties.
+     * Wraps the provided value in a property and sets it at the specified index
+     * effectively replacing the property at that index.
+     *
+     * @param index The index at which to set the property.
+     * @param item  The value to set.
+     * @return This list of properties.
+     * @throws IllegalArgumentException  If the given item is null and the list was not created with the
+     *                                   "ofNullable(...)" factory method.
+     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    default Vars<T> setAt( int index, T item ) { return setAt(index, Var.of(item)); }
+    Vars<@Nullable T> setAt( int index, @Nullable T item );
 
     /**
-     *  Places the provided property at the specified index, effectively replacing the property
-     *  at that index.
-     *  @param index The index at which to set the property.
-     *  @param var The property to set.
-     *  @return This list of properties.
+     * Places the provided property at the specified index, effectively replacing the property
+     * at that index.
+     *
+     * @param index The index at which to set the property.
+     * @param var   The property to set.
+     * @return This list of properties.
+     * @throws IllegalArgumentException  If given var is nullable and the list was not created with the
+     *                                   "ofNullable(...)" factory method.
+     * @throws IllegalArgumentException  If given {@code var} is not nullable and the list is nullable.
+     * @throws IndexOutOfBoundsException If the given index is out of bounds.
      */
-    Vars<T> setAt( int index, Var<T> var );
+    Vars<@Nullable T> setAt( int index, Var<@Nullable T> var );
 
     /**
-     *  Wraps each provided item in a property and appends it to this
-     *  list of properties.
-     *  @param items The array of values to add as property items.
-     *  @return This list of properties.
+     * Wraps each provided item in a property and appends it to this
+     * list of properties.
+     *
+     * @param items The array of values to add as property items.
+     * @return This list of properties.
+     * @throws IllegalArgumentException If one of the given items is null and the list was not created with the
+     *                                  "ofNullable(...)" factory method.
      */
     @SuppressWarnings("unchecked")
-    default Vars<T> addAll( T... items )
-    {
-        Vars<T> vars = Vars.of(this.type());
-        for ( T v : items ) vars.add(v);
-        return this.addAll(vars);
-    }
+    Vars<@Nullable T> addAll( @Nullable T @NonNull... items );
 
     /**
      *  Iterates over the supplied values, and appends
      *  them to this list as properties.
      *  @param items The values to add as property items.
      *  @return This list of properties.
+     *  @throws IllegalArgumentException If one of the given items is null and the list was not created with the
+     *                                  "ofNullable(...)" factory method.
      */
-    default Vars<T> addAll( Iterable<T> items )
-    {
-        Vars<T> vars = Vars.of(this.type());
-        for ( T v : items ) vars.add(v);
-        return this.addAll(vars);
-    }
+    Vars<@Nullable T> addAll( Iterable<@Nullable T> items );
 
     /**
-     *  Iterates over the supplied property list, and appends
-     *  them to this list.
-     *  @param vals The properties to add.
-     *  @return This list of properties.
+     * Iterates over the supplied property list, and appends
+     * them to this list.
+     * Note: If the property list {@code vals} is immutable we append a copy of the properties it contains.
+     *
+     * @param vals The properties to add.
+     * @return This list of properties.
+     * @throws IllegalArgumentException If the provided list was created with "ofNullable(...)" and this list was not
+     *                                  created with the "ofNullable(...)" factory method.
+     * @throws IllegalArgumentException If the provided list was not created with "ofNullable(...)" and this list was
+     *                                  created with the "ofNullable(...)" factory method.
      */
-    default Vars<T> addAll( Vals<T> vals )
-    {
-        for ( T v : vals ) add(v);
-        return this;
-    }
+    Vars<@Nullable T> addAll( Vals<@Nullable T> vals );
 
     /**
      *  The {@link #retainAll(Vars)} method removes all properties from this list
@@ -485,7 +488,7 @@ public interface Vars<T> extends Vals<T>
      *              All other properties will be removed.
      *  @return This list of properties.
      */
-    Vars<T> retainAll( Vars<T> vars );
+    Vars<@Nullable T> retainAll( Vars<@Nullable T> vars );
 
     /**
      *  This method removes all properties from this list
@@ -494,12 +497,7 @@ public interface Vars<T> extends Vals<T>
      *               All other properties will be removed.
      *  @return This list of properties.
      */
-    default Vars<T> retainAll( T... items )
-    {
-        Vars<T> vars = Vars.of(type());
-        for ( T item : items ) vars.add(Var.of(item));
-        return retainAll(vars);
-    }
+    Vars<@Nullable T> retainAll( @Nullable T @NonNull... items );
 
     /**
      *  Removes all properties from this list.
@@ -508,41 +506,16 @@ public interface Vars<T> extends Vals<T>
      *
      * @return This list.
      */
-    Vars<T> clear();
+    Vars<@Nullable T> clear();
 
-    /**
-     *  Use this for mapping a list of properties to another list of properties.
-     */
-    @Override default Vars<T> map( Function<T,T> mapper ) {
-        Objects.requireNonNull(mapper);
-        @SuppressWarnings("unchecked")
-        Var<T>[] vars = new Var[size()];
-        int i = 0;
-        for ( T v : this ) vars[i++] = Var.of( mapper.apply(v) );
-        return Vars.of( type(), vars );
-    }
-
-    /**
-     *  Use this for mapping a list of properties to another list of properties.
-     */
-    @Override default <U> Vars<U> mapTo( Class<U> type, Function<T,U> mapper ) {
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(mapper);
-        @SuppressWarnings("unchecked")
-        Var<U>[] vars = new Var[size()];
-        for ( int i = 0; i < size(); i++ )
-            vars[i] = this.at( i ).mapTo( type, mapper );
-        return Vars.of( type, vars );
-    }
-
-    default Vals<T> toVals() { return Vals.of( type(), this ); }
+    Vals<@Nullable T> toVals();
 
     /**
      *  Use this for sorting the list of properties.
      *
      * @param comparator The comparator to use for sorting.
      */
-    void sort( Comparator<T> comparator );
+    void sort( Comparator<@Nullable T> comparator );
 
     /**
      * Sorts the list of properties using the natural ordering of the
@@ -571,5 +544,5 @@ public interface Vars<T> extends Vals<T>
      *
      * @return This list.
      */
-    Vars<T> revert();
+    Vars<@Nullable T> revert();
 }

--- a/src/main/java/sprouts/impl/AbstractValue.java
+++ b/src/main/java/sprouts/impl/AbstractValue.java
@@ -14,7 +14,7 @@ import java.util.*;
  *
  *  @param <T> The type of the value.
  */
-abstract class AbstractValue<T> implements Val<T>
+abstract class AbstractValue<T extends @Nullable Object> implements Val<T>
 {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(AbstractValue.class);
 

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -35,7 +35,7 @@ public class AbstractVariable<T> extends AbstractValue<T> implements Var<T>
 		return of( false, first, second, combiner );
 	}
 
-	public static <T> Var<T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	public static <T> Var<@Nullable T> ofNullable( Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner ) {
 		return of( true, first, second, combiner );
 	}
 

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -39,7 +39,7 @@ public class AbstractVariable<T> extends AbstractValue<T> implements Var<T>
 		return of( true, first, second, combiner );
 	}
 
-	private static <T> Var<T> of( boolean allowNull, Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	private static <T> Var<@Nullable T> of( boolean allowNull, Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner ) {
 		String id = "";
 		if ( !first.id().isEmpty() && !second.id().isEmpty() )
 			id = first.id() + "_and_" + second.id();

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -16,9 +16,8 @@ import java.util.function.Consumer;
  * 
  * @param <T> The type of the value wrapped by a given property...
  */
-public class AbstractVariable<T> extends AbstractValue<T> implements Var<T>
-{
-	public static <T> Var<T> ofNullable( boolean immutable, Class<T> type, @Nullable T value ) {
+public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<T> implements Var<T> {
+	public static <T> Var<@Nullable T> ofNullable( boolean immutable, Class<T> type, @Nullable T value ) {
 		return new AbstractVariable<T>( immutable, type, value, NO_ID, Collections.emptyMap(), true );
 	}
 
@@ -35,11 +34,11 @@ public class AbstractVariable<T> extends AbstractValue<T> implements Var<T>
 		return of( false, first, second, combiner );
 	}
 
-	public static <T> Var<T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	public static <T extends @Nullable Object> Var<@Nullable T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		return of( true, first, second, combiner );
 	}
 
-	private static <T> Var<T> of( boolean allowNull, Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	private static <T extends @Nullable Object> Var<T> of( boolean allowNull, Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		String id = "";
 		if ( !first.id().isEmpty() && !second.id().isEmpty() )
 			id = first.id() + "_and_" + second.id();

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -39,7 +39,7 @@ public class AbstractVariable<T> extends AbstractValue<T> implements Var<T>
 		return of( true, first, second, combiner );
 	}
 
-	private static <T> Var<@Nullable T> of( boolean allowNull, Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner ) {
+	private static <T> Var<T> of( boolean allowNull, Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		String id = "";
 		if ( !first.id().isEmpty() && !second.id().isEmpty() )
 			id = first.id() + "_and_" + second.id();

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -35,7 +35,7 @@ public class AbstractVariable<T> extends AbstractValue<T> implements Var<T>
 		return of( false, first, second, combiner );
 	}
 
-	public static <T> Var<@Nullable T> ofNullable( Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner ) {
+	public static <T> Var<T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		return of( true, first, second, combiner );
 	}
 

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -1,5 +1,6 @@
 package sprouts.impl;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import sprouts.Observable;
 import sprouts.Observer;
@@ -8,6 +9,7 @@ import sprouts.*;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * 	The base implementation for both {@link Var} and {@link Val} interfaces.
@@ -172,28 +174,20 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 	}
 
 	/** {@inheritDoc} */
-	@Override public final <U> Val<U> viewAs( Class<U> type, java.util.function.Function<T, U> mapper ) {
+	@Override public final <U extends @Nullable Object> Val<@Nullable U> viewAs(Class<@NonNull U> type, Function<T, @Nullable U> mapper ) {
 		boolean nullCanBeAvoided = _isPrimitiveRef(type) || type == String.class;
-		Var<U> var;
-		if ( nullCanBeAvoided )
-		{
-			@Nullable U result = _mapOrGetNullObjectOf(type, this.orElseNull(), mapper);
-			if ( result == null )
-				var = Var.ofNull( type );
-			else
-				var = Var.of(result);
+		final Var<@Nullable U> var;
+		if ( nullCanBeAvoided ) {
+			U result = _mapOrGetNullObjectOf(type, orElseNull(), mapper);
+			var = Var.of(result);
 			// Now we register a live update listener to this property
-			this.onChange( DEFAULT_CHANNEL, v -> var.set( _mapOrGetNullObjectOf( type, v.orElseNull(), mapper ) ));
+			onChange( DEFAULT_CHANNEL, v -> var.set( _mapOrGetNullObjectOf( type, v.orElseNull(), mapper ) ));
 			_viewers.add( v -> var.set(From.VIEW, _mapOrGetNullObjectOf(type, v, mapper)) );
-		}
-		else
-		{
-			if ( this.allowsNull() )
-				var = Var.ofNullable( type, mapper.apply( this.orElseNull() ) );
-			else
-				var = Var.of( type, mapper.apply( this.get() ) );
+		} else {
+			// If we allow U to be nullable, we must return a nullable Val; we can't check it at runtime
+			var = Var.ofNullable(type, mapper.apply(orElseNull()));
 			// Now we register a live update listener to this property
-			this.onChange( DEFAULT_CHANNEL, v -> var.set( mapper.apply( v.orElseNull() ) ));
+			onChange( DEFAULT_CHANNEL, v -> var.set( mapper.apply( v.orElseNull() ) ));
 			_viewers.add( v -> var.set(From.VIEW, mapper.apply( v ) ) );
 		}
 		return var;
@@ -217,9 +211,9 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 			return false;
 	}
 
-	private <I,N> @Nullable N _mapOrGetNullObjectOf(Class<N> type, @Nullable I in, java.util.function.Function<I, N> mapper ) {
+	private <I,N> N _mapOrGetNullObjectOf(Class<N> type, @Nullable I in, Function<I, @Nullable N> mapper ) {
 		boolean inIsNull = in == null;
-		@Nullable N value;
+		N value;
 		try {
 			value = mapper.apply(in);
 		} catch ( Exception e ) {
@@ -228,7 +222,32 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 			else
 				throw e;
 		}
-		return _itemNullObjectOrNullOf(type, value);
+		return _itemNullObjectOrThrowOf(type, value);
+	}
+
+	private static <T> T _itemNullObjectOrThrowOf(Class<T> type, @Nullable T value ) {
+		if  ( value != null )
+			return value;
+		else if ( type == String.class )
+			return type.cast("");
+		else if ( type == Integer.class )
+			return type.cast(0);
+		else if ( type == Long.class )
+			return type.cast(0L);
+		else if ( type == Double.class )
+			return type.cast(0.0);
+		else if ( type == Float.class )
+			return type.cast(0.0f);
+		else if ( type == Short.class )
+			return type.cast((short)0);
+		else if ( type == Byte.class )
+			return type.cast((byte)0);
+		else if ( type == Character.class )
+			return type.cast((char)0);
+		else if ( type == Boolean.class )
+			return type.cast(false);
+		else
+			throw new IllegalArgumentException(String.format("The given item of type '%s' cannot be mapped to a null object.", type.getSimpleName()));
 	}
 
 	private static <T> @Nullable T _itemNullObjectOrNullOf(Class<T> type, @Nullable T value ) {

--- a/src/main/java/sprouts/impl/AbstractVariables.java
+++ b/src/main/java/sprouts/impl/AbstractVariables.java
@@ -339,6 +339,11 @@ public class AbstractVariables<T> implements Vars<T>
         return this;
     }
 
+    @Override
+    public boolean allowsNull() {
+        return _allowsNull;
+    }
+
     private ValsDelegate<T> _createDelegate(
             int index, Change type, @Nullable Var<T> newVal, @Nullable Var<T> oldVal
     ) {

--- a/src/main/java/sprouts/impl/AbstractVariables.java
+++ b/src/main/java/sprouts/impl/AbstractVariables.java
@@ -65,29 +65,29 @@ public class AbstractVariables<T> implements Vars<T>
         return AbstractVariables.of( immutable, type, (Iterable) list );
     }
 
-    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type ){
+    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type ){
         Objects.requireNonNull(type);
-        return new AbstractVariables<T>( immutable, type, true, new Var[0] ){};
+        return new AbstractVariables<@Nullable T>( immutable, type, true, new Var[0] ){};
     }
 
     @SafeVarargs
-    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, Var<T>... vars ) {
+    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type, Var<@Nullable T>... vars ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(vars);
-        return new AbstractVariables<T>( immutable, type, true, vars ){};
+        return new AbstractVariables<@Nullable T>( immutable, type, true, vars ){};
     }
 
     @SafeVarargs
-    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, T... vars ) {
+    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type, @Nullable T... vars ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(vars);
         Var<T>[] array = new Var[vars.length];
         for ( int i = 0; i < vars.length; i++ ) array[i] = Var.ofNullable(type, vars[i]);
-        return new AbstractVariables<T>( immutable, type, true, array ){};
+        return new AbstractVariables<@Nullable T>( immutable, type, true, array ){};
     }
 
     @SafeVarargs
-    public static <T> Vars<T> ofNullable( boolean immutable, Var<T> first, Var<T>... vars ) {
+    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Var<@Nullable T> first, Var<@Nullable T>... vars ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(vars);
         Var<T>[] array = new Var[vars.length+1];
@@ -96,7 +96,7 @@ public class AbstractVariables<T> implements Vars<T>
         return ofNullable(immutable, first.type(), array);
     }
 
-    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, Iterable<Var<T>> vars ) {
+    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type, Iterable<Var<@Nullable T>> vars ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(vars);
         List<Var<T>> list = new ArrayList<>();
@@ -105,7 +105,7 @@ public class AbstractVariables<T> implements Vars<T>
         return new AbstractVariables<T>( immutable, type, true, list.toArray(array) ){};
     }
 
-    public static <T> Vals<T> ofNullable( boolean immutable, Class<T> type, Vals<T> vals ) {
+    public static <T> Vals<@Nullable T> ofNullable( boolean immutable, Class<T> type, Vals<@Nullable T> vals ) {
         if ( vals instanceof AbstractVariables )
             return new AbstractVariables<>( immutable, type, true, ((AbstractVariables<T>) vals)._variables );
 

--- a/src/main/java/sprouts/impl/AbstractVariables.java
+++ b/src/main/java/sprouts/impl/AbstractVariables.java
@@ -75,7 +75,7 @@ public class AbstractVariables<T> implements Vars<T>
     }
 
     @SafeVarargs
-    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, T... vars ) {
+    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type, @Nullable T... vars ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(vars);
         Var<T>[] array = new Var[vars.length];

--- a/src/main/java/sprouts/impl/AbstractVariables.java
+++ b/src/main/java/sprouts/impl/AbstractVariables.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 /**
  *  A base class for {@link Vars} implementations.
  */
-public class AbstractVariables<T> implements Vars<T>
+public class AbstractVariables<T extends @Nullable Object> implements Vars<T>
 {
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(AbstractVariables.class);
 

--- a/src/main/java/sprouts/impl/AbstractVariables.java
+++ b/src/main/java/sprouts/impl/AbstractVariables.java
@@ -1,5 +1,6 @@
 package sprouts.impl;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import sprouts.*;
@@ -7,6 +8,8 @@ import sprouts.Observable;
 import sprouts.Observer;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -93,8 +96,25 @@ public class AbstractVariables<T> implements Vars<T>
         return ofNullable(immutable, first.type(), array);
     }
 
+    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, Iterable<Var<T>> vars ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(vars);
+        List<Var<T>> list = new ArrayList<>();
+        vars.forEach( list::add );
+        Var<T>[] array = new Var[list.size()];
+        return new AbstractVariables<T>( immutable, type, true, list.toArray(array) ){};
+    }
 
-    private final List<Var<T>> _variables = new ArrayList<>();
+    public static <T> Vals<T> ofNullable( boolean immutable, Class<T> type, Vals<T> vals ) {
+        if ( vals instanceof AbstractVariables )
+            return new AbstractVariables<>( immutable, type, true, ((AbstractVariables<T>) vals)._variables );
+
+        List<Val<T>> list = new ArrayList<>();
+        for ( int i = 0; i < vals.size(); i++ ) list.add( vals.at(i) );
+        return AbstractVariables.ofNullable( immutable, type, (Iterable) list );
+    }
+
+    private final List<Var<@Nullable T>> _variables = new ArrayList<>();
     private final boolean _isImmutable;
     private final boolean _allowsNull;
     private final Class<T> _type;
@@ -122,6 +142,12 @@ public class AbstractVariables<T> implements Vars<T>
     /** {@inheritDoc} */
     @Override public final Var<T> at( int index ) { return _variables.get(index); }
 
+    @Override
+    public Vars<@Nullable T> add(@Nullable T value) {
+        Var<@Nullable T> var = _allowsNull ? Var.ofNullable(type(), value) : Var.ofOrThrow(value);
+        return add(var);
+    }
+
     /** {@inheritDoc} */
     @Override public final Class<T> type() { return _type; }
 
@@ -146,15 +172,15 @@ public class AbstractVariables<T> implements Vars<T>
      *  @param count The number of properties to remove.
      *  @return A new list of properties.
      */
-    @Override public Vars<T> popLast( int count )
+    @Override public Vars<@Nullable T> popLast( int count )
     {
         if ( _isImmutable ) throw new UnsupportedOperationException( "This list is immutable." );
         count = Math.min( count, size() );
-        if ( count == 0 ) return Vars.of(type());
-        if ( count == 1 ) return Vars.of(popLast());
-        Vars<T> vars = Vars.of(type());
-        List<Var<T>> subList = _variables.subList( size() - count, size() );
-        for ( Var<T> var : subList ) vars.add(var);
+        if ( count == 0 ) return _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+        if ( count == 1 ) return _allowsNull ? Vars.ofNullable(type(), popLast()) : Vars.of(popLast());
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+        List<Var<@Nullable T>> subList = _variables.subList( size() - count, size() );
+        for ( Var<@Nullable T> var : subList ) vars.add(var);
         subList.clear();
         _triggerAction( Change.REMOVE, -1, null, null );
         return vars;
@@ -165,7 +191,7 @@ public class AbstractVariables<T> implements Vars<T>
      *  @param count The number of properties to remove.
      *  @return This list of properties.
      */
-    @Override public Vars<T> removeFirst( int count )
+    @Override public Vars<@Nullable T> removeFirst( int count )
     {
         if ( _isImmutable ) throw new UnsupportedOperationException( "This list is immutable." );
         count = Math.min( count, size() );
@@ -182,7 +208,7 @@ public class AbstractVariables<T> implements Vars<T>
      *  @param count The number of properties to remove.
      *  @return A new list of properties.
      */
-    @Override public Vars<T> popFirst( int count )
+    @Override public Vars<@Nullable T> popFirst( int count )
     {
         if ( _isImmutable ) throw new UnsupportedOperationException( "This list is immutable." );
         count = Math.min( count, size() );
@@ -196,8 +222,48 @@ public class AbstractVariables<T> implements Vars<T>
         return vars;
     }
 
+    @Override
+    public Vars<@Nullable T> removeIf(Predicate<Var<@Nullable T>> predicate) {
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+        for (int i = size() - 1; i >= 0; i--)
+            if (predicate.test(this.at(i))) vars.add(this.at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return this;
+    }
+
+    @Override
+    public Vars<@Nullable T> popIf(Predicate<Var<@Nullable T>> predicate) {
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+        for ( int i = size() - 1; i >= 0; i-- )
+            if ( predicate.test(this.at(i)) ) vars.add(this.at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return vars.revert();
+    }
+
+    @Override
+    public Vars<@Nullable T> removeIfItem(Predicate<@Nullable T> predicate) {
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+        for ( int i = size() - 1; i >= 0; i-- )
+            if ( predicate.test(this.at(i).get()) ) vars.add(this.at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return this;
+    }
+
+    @Override
+    public Vars<@Nullable T> popIfItem(Predicate<@Nullable T> predicate) {
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+        for (int i = size() - 1; i >= 0; i--)
+            if (predicate.test(at(i).get())) vars.add(at(i));
+
+        this.removeAll(vars); // remove from this list at once and trigger events only once!
+        return vars.revert();
+    }
+
     /** {@inheritDoc} */
-    @Override public Vars<T> removeAll( Vars<T> vars )
+    @Override public Vars<T> removeAll( Vars<@Nullable T> vars )
     {
         if ( _isImmutable ) throw new UnsupportedOperationException("This is an immutable list.");
         for ( int i = size() - 1; i >= 0; i-- )
@@ -210,6 +276,18 @@ public class AbstractVariables<T> implements Vars<T>
 
     /** {@inheritDoc} */
     @Override
+    public Vars<@Nullable T> addAt(int index, @Nullable T item) {
+        if (_allowsNull)
+            return addAt(index, Var.ofNullable(type(), item));
+
+        if (item == null)
+            throw new IllegalArgumentException("Null values are not allowed in this property list.");
+
+        return addAt(index, Var.of(item));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public Vars<T> addAt( int index, Var<T> value ) {
         if ( _isImmutable ) throw new UnsupportedOperationException("This is an immutable list.");
         _checkNullSafetyOf(value);
@@ -218,9 +296,20 @@ public class AbstractVariables<T> implements Vars<T>
         return this;
     }
 
+    @Override
+    public Vars<@Nullable T> setAt(int index, @Nullable T item) {
+        if (_allowsNull)
+            return setAt(index, Var.ofNullable(type(), item));
+
+        if (item == null)
+            throw new IllegalArgumentException("Null values are not allowed in this property list.");
+
+        return setAt(index, Var.of(item));
+    }
+
     /** {@inheritDoc} */
     @Override
-    public Vars<T> removeAt( int index ) {
+    public Vars<@Nullable T> removeAt( int index ) {
         if ( _isImmutable ) throw new UnsupportedOperationException("This is an immutable list.");
         if ( index < 0 || index >= _variables.size() )
             throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + _variables.size());
@@ -248,9 +337,32 @@ public class AbstractVariables<T> implements Vars<T>
         return this;
     }
 
+    @Override
+    public Vars<@Nullable T> addAll( @Nullable T @NonNull ... items ) {
+        Objects.requireNonNull(items);
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+
+        for (@Nullable T v : items) {
+            vars.add(v);
+        }
+
+        return this.addAll(vars);
+    }
+
     /** {@inheritDoc} */
-    @Override public Vars<T> addAll( Vals<T> vals )
-    {
+    @Override
+    public Vars<@Nullable T> addAll( Iterable<@Nullable T> items ) {
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+
+        for (@Nullable T v : items) {
+            vars.add(v);
+        }
+
+        return this.addAll(vars);
+    }
+
+    /** {@inheritDoc} */
+    @Override public Vars<T> addAll( Vals<@Nullable T> vals ) {
         if ( _isImmutable ) throw new UnsupportedOperationException("This is an immutable list.");
         for ( int i = 0; i < vals.size(); i++ ) {
             Val<T> val = vals.at(i);
@@ -259,7 +371,7 @@ public class AbstractVariables<T> implements Vars<T>
             if ( val instanceof Var )
                 _variables.add((Var<T>) val);
             else
-                _variables.add(Var.of(val.get()));
+                _variables.add(_allowsNull ? Var.ofNullable(type(), val.orElseNull()) : Var.of(val.get()));
         }
         if ( vals.isNotEmpty() ) {
             if ( vals.size() > 1 )
@@ -272,14 +384,22 @@ public class AbstractVariables<T> implements Vars<T>
 
     /** {@inheritDoc} */
     @Override
-    public Vars<T> retainAll( Vars<T> vars ) {
+    public Vars<@Nullable T> retainAll( Vars<@Nullable T> vars ) {
         if ( _isImmutable ) throw new UnsupportedOperationException("This is an immutable list.");
 
-        boolean changed = _variables.retainAll(vars.toValList());
+        boolean changed = _variables.removeIf(v -> !vars.contains(v));
         if ( changed )
             _triggerAction( Change.REMOVE, -1, null, null );
 
         return this;
+    }
+
+    @Override
+    public Vars<@Nullable T> retainAll(@Nullable T @NonNull ... items) {
+        Objects.requireNonNull(items);
+        Vars<@Nullable T> vars = _allowsNull ? Vars.ofNullable(type()) : Vars.of(type());
+        for (@Nullable T item : items) vars.add(_allowsNull ? Var.ofNullable(type(), item) : Var.ofOrThrow(item));
+        return retainAll(vars);
     }
 
     /** {@inheritDoc} */
@@ -289,6 +409,11 @@ public class AbstractVariables<T> implements Vars<T>
         _variables.clear();
         _triggerAction( Change.CLEAR, -1, null, null );
         return this;
+    }
+
+    @Override
+    public Vals<@Nullable T> toVals() {
+        return _allowsNull ? Vals.ofNullable(type(), this) : Vals.of(type(), this);
     }
 
     /** {@inheritDoc} */
@@ -339,6 +464,34 @@ public class AbstractVariables<T> implements Vars<T>
         return this;
     }
 
+    @Override
+    public Vals<@Nullable T> map(Function<@Nullable T, @Nullable T> mapper) {
+        Objects.requireNonNull(mapper);
+        @SuppressWarnings("unchecked")
+        Var<T>[] vars = new Var[size()];
+        int i = 0;
+        for ( T v : this ) vars[i++] = _allowsNull ? Var.ofNullable(type(), mapper.apply(v) ) : Var.ofOrThrow(mapper.apply(v));
+        return Vals.of( type(), vars );
+    }
+
+    @Override
+    public <U> Vals<@Nullable U> mapTo(Class<U> type, Function<@Nullable T, @Nullable U> mapper) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(mapper);
+        @SuppressWarnings("unchecked")
+        Var<U>[] vars = new Var[size()];
+        for ( int i = 0; i < size(); i++ )
+            vars[i] = this.at( i ).mapTo( type, mapper );
+        return Vars.of( type, vars );
+    }
+
+    @Override
+    public List<Val<@Nullable T>> toValList() {
+        return Collections.unmodifiableList(
+                stream().map(v -> _allowsNull ? Val.ofNullable(type(), v) : Val.of(Objects.requireNonNull(v)) ).collect(Collectors.toList())
+        );
+    }
+
     private ValsDelegate<T> _createDelegate(
             int index, Change type, @Nullable Var<T> newVal, @Nullable Var<T> oldVal
     ) {
@@ -369,7 +522,7 @@ public class AbstractVariables<T> implements Vars<T>
 
     /** {@inheritDoc} */
     @Override
-    public java.util.Iterator<T> iterator() {
+    public java.util.Iterator<@Nullable T> iterator() {
         return new java.util.Iterator<T>() {
             private int index = 0;
             @Override public boolean hasNext() { return index < size(); }
@@ -423,6 +576,8 @@ public class AbstractVariables<T> implements Vars<T>
         Objects.requireNonNull(value);
         if ( !_allowsNull && value.allowsNull() )
             throw new IllegalArgumentException("Null values are not allowed in this property list.");
+        if ( _allowsNull && !value.allowsNull() )
+            throw new IllegalArgumentException("Null values are allowed in this property list.");
     }
 
     @Override

--- a/src/main/java/sprouts/impl/AbstractVariables.java
+++ b/src/main/java/sprouts/impl/AbstractVariables.java
@@ -65,29 +65,29 @@ public class AbstractVariables<T> implements Vars<T>
         return AbstractVariables.of( immutable, type, (Iterable) list );
     }
 
-    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type ){
+    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type ){
         Objects.requireNonNull(type);
-        return new AbstractVariables<@Nullable T>( immutable, type, true, new Var[0] ){};
+        return new AbstractVariables<T>( immutable, type, true, new Var[0] ){};
     }
 
     @SafeVarargs
-    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type, Var<@Nullable T>... vars ) {
+    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, Var<T>... vars ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(vars);
-        return new AbstractVariables<@Nullable T>( immutable, type, true, vars ){};
+        return new AbstractVariables<T>( immutable, type, true, vars ){};
     }
 
     @SafeVarargs
-    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type, @Nullable T... vars ) {
+    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, T... vars ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(vars);
         Var<T>[] array = new Var[vars.length];
         for ( int i = 0; i < vars.length; i++ ) array[i] = Var.ofNullable(type, vars[i]);
-        return new AbstractVariables<@Nullable T>( immutable, type, true, array ){};
+        return new AbstractVariables<T>( immutable, type, true, array ){};
     }
 
     @SafeVarargs
-    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Var<@Nullable T> first, Var<@Nullable T>... vars ) {
+    public static <T> Vars<T> ofNullable( boolean immutable, Var<T> first, Var<T>... vars ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(vars);
         Var<T>[] array = new Var[vars.length+1];
@@ -96,7 +96,7 @@ public class AbstractVariables<T> implements Vars<T>
         return ofNullable(immutable, first.type(), array);
     }
 
-    public static <T> Vars<@Nullable T> ofNullable( boolean immutable, Class<T> type, Iterable<Var<@Nullable T>> vars ) {
+    public static <T> Vars<T> ofNullable( boolean immutable, Class<T> type, Iterable<Var<T>> vars ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(vars);
         List<Var<T>> list = new ArrayList<>();
@@ -105,7 +105,7 @@ public class AbstractVariables<T> implements Vars<T>
         return new AbstractVariables<T>( immutable, type, true, list.toArray(array) ){};
     }
 
-    public static <T> Vals<@Nullable T> ofNullable( boolean immutable, Class<T> type, Vals<@Nullable T> vals ) {
+    public static <T> Vals<T> ofNullable( boolean immutable, Class<T> type, Vals<T> vals ) {
         if ( vals instanceof AbstractVariables )
             return new AbstractVariables<>( immutable, type, true, ((AbstractVariables<T>) vals)._variables );
 

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -201,6 +201,10 @@ public final class Sprouts implements SproutsFactory
         return AbstractVariables.ofNullable( true, (Var<T>) first, vars );
     }
 
+    @Override
+    public <T> Vals<T> valsOfNullable(Class<T> type, Vals<T> vals) {
+        return AbstractVariables.ofNullable( true, type, vals );
+    }
 
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -94,11 +94,11 @@ public final class Sprouts implements SproutsFactory
         };
     }
 
-    @Override public <T> Val<T> valOfNullable( Class<T> type, @Nullable T item ) {
+    @Override public <T> Val<@Nullable T> valOfNullable( Class<T> type, @Nullable T item ) {
         return AbstractVariable.ofNullable( true, type, item );
     }
 
-    @Override public <T> Val<T> valOfNull( Class<T> type ) {
+    @Override public <T> Val<@Nullable T> valOfNull( Class<T> type ) {
         return AbstractVariable.ofNullable( true, type, null );
     }
 
@@ -111,7 +111,7 @@ public final class Sprouts implements SproutsFactory
         return Val.of( toBeCopied.get() ).withId( toBeCopied.id() );
     }
 
-    @Override public <T> Val<T> valOfNullable(Val<T> toBeCopied ) {
+    @Override public <T> Val<@Nullable T> valOfNullable(Val<@Nullable T> toBeCopied ) {
         Objects.requireNonNull(toBeCopied);
         return Val.ofNullable( toBeCopied.type(), toBeCopied.orElseNull() ).withId( toBeCopied.id() );
     }
@@ -125,7 +125,7 @@ public final class Sprouts implements SproutsFactory
         return AbstractVariable.of( first, second, combiner );
     }
 
-    @Override public <T> Val<T> valOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+    @Override public <T extends @Nullable Object> Val<@Nullable T> valOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
         Objects.requireNonNull(combiner);

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -179,23 +179,23 @@ public final class Sprouts implements SproutsFactory
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<T> valsOfNullable( Class<T> type, Val<T>... vals ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type, Val<@Nullable T>... vals ) {
         Var<T>[] vars = new Var[vals.length];
         System.arraycopy(vals, 0, vars, 0, vals.length);
         return AbstractVariables.ofNullable( true, type, vars );
     }
 
-    @Override public <T> Vals<T> valsOfNullable( Class<T> type ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type ) {
         return AbstractVariables.ofNullable( true, type );
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<T> valsOfNullable( Class<T> type, T... items ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type, @Nullable T... items ) {
         return AbstractVariables.ofNullable( true, type, items );
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<T> valsOfNullable( Val<T> first, Val<T>... rest ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Val<@Nullable T> first, Val<@Nullable T>... rest ) {
         Var<T>[] vars = new Var[rest.length];
         System.arraycopy(rest, 0, vars, 0, rest.length);
         return AbstractVariables.ofNullable( true, (Var<T>) first, vars );

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -111,7 +111,7 @@ public final class Sprouts implements SproutsFactory
         return Val.of( toBeCopied.get() ).withId( toBeCopied.id() );
     }
 
-    @Override public <T> Val<T> valOfNullable(Val<T> toBeCopied ) {
+    @Override public <T> Val<@Nullable T> valOfNullable(Val<@Nullable T> toBeCopied ) {
         Objects.requireNonNull(toBeCopied);
         return Val.ofNullable( toBeCopied.type(), toBeCopied.orElseNull() ).withId( toBeCopied.id() );
     }
@@ -125,7 +125,7 @@ public final class Sprouts implements SproutsFactory
         return AbstractVariable.of( first, second, combiner );
     }
 
-    @Override public <T> Val<T> valOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+    @Override public <T> Val<@Nullable T> valOfNullable(Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
         Objects.requireNonNull(combiner);
@@ -179,30 +179,30 @@ public final class Sprouts implements SproutsFactory
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<T> valsOfNullable( Class<T> type, Val<T>... vals ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type, Val<@Nullable T>... vals ) {
         Var<T>[] vars = new Var[vals.length];
         System.arraycopy(vals, 0, vars, 0, vals.length);
         return AbstractVariables.ofNullable( true, type, vars );
     }
 
-    @Override public <T> Vals<T> valsOfNullable( Class<T> type ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type ) {
         return AbstractVariables.ofNullable( true, type );
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<T> valsOfNullable( Class<T> type, T... items ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type, @Nullable T... items ) {
         return AbstractVariables.ofNullable( true, type, items );
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<T> valsOfNullable( Val<T> first, Val<T>... rest ) {
+    @Override public <T> Vals<@Nullable T> valsOfNullable( Val<@Nullable T> first, Val<@Nullable T>... rest ) {
         Var<T>[] vars = new Var[rest.length];
         System.arraycopy(rest, 0, vars, 0, rest.length);
         return AbstractVariables.ofNullable( true, (Var<T>) first, vars );
     }
 
     @Override
-    public <T> Vals<T> valsOfNullable(Class<T> type, Vals<T> vals) {
+    public <T> Vals<@Nullable T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals) {
         return AbstractVariables.ofNullable( true, type, vals );
     }
 
@@ -221,19 +221,19 @@ public final class Sprouts implements SproutsFactory
 	@Override public <T> Vars<T> varsOf( Class<T> type, Iterable<Var<T>> vars ) { return AbstractVariables.of( false, type, vars ); }
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<T> varsOfNullable( Class<T> type, Var<T>... vars ) {
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type, Var<@Nullable T>... vars ) {
 		return AbstractVariables.ofNullable( false, type, vars );
 	}
 
-	@Override public <T> Vars<T> varsOfNullable( Class<T> type ) { return AbstractVariables.ofNullable( false, type ); }
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type ) { return AbstractVariables.ofNullable( false, type ); }
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<T> varsOfNullable( Class<T> type, T... values ) {
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type, @Nullable T... values ) {
 		return AbstractVariables.ofNullable( false, type, values );
 	}
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<T> varsOfNullable( Var<T> first, Var<T>... rest ) {
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Var<@Nullable T> first, Var<@Nullable T>... rest ) {
 		return AbstractVariables.ofNullable( false, first, rest );
 	}
 

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -201,10 +201,6 @@ public final class Sprouts implements SproutsFactory
         return AbstractVariables.ofNullable( true, (Var<T>) first, vars );
     }
 
-    @Override
-    public <T> Vals<T> valsOfNullable(Class<T> type, Vals<T> vals) {
-        return AbstractVariables.ofNullable( true, type, vals );
-    }
 
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -217,19 +217,19 @@ public final class Sprouts implements SproutsFactory
 	@Override public <T> Vars<T> varsOf( Class<T> type, Iterable<Var<T>> vars ) { return AbstractVariables.of( false, type, vars ); }
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<T> varsOfNullable( Class<T> type, Var<T>... vars ) {
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type, Var<@Nullable T>... vars ) {
 		return AbstractVariables.ofNullable( false, type, vars );
 	}
 
-	@Override public <T> Vars<T> varsOfNullable( Class<T> type ) { return AbstractVariables.ofNullable( false, type ); }
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type ) { return AbstractVariables.ofNullable( false, type ); }
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<T> varsOfNullable( Class<T> type, T... values ) {
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type, @Nullable T... values ) {
 		return AbstractVariables.ofNullable( false, type, values );
 	}
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<T> varsOfNullable( Var<T> first, Var<T>... rest ) {
+	@Override public <T> Vars<@Nullable T> varsOfNullable( Var<@Nullable T> first, Var<@Nullable T>... rest ) {
 		return AbstractVariables.ofNullable( false, first, rest );
 	}
 

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -111,7 +111,7 @@ public final class Sprouts implements SproutsFactory
         return Val.of( toBeCopied.get() ).withId( toBeCopied.id() );
     }
 
-    @Override public <T> Val<@Nullable T> valOfNullable(Val<@Nullable T> toBeCopied ) {
+    @Override public <T> Val<T> valOfNullable(Val<T> toBeCopied ) {
         Objects.requireNonNull(toBeCopied);
         return Val.ofNullable( toBeCopied.type(), toBeCopied.orElseNull() ).withId( toBeCopied.id() );
     }
@@ -125,7 +125,7 @@ public final class Sprouts implements SproutsFactory
         return AbstractVariable.of( first, second, combiner );
     }
 
-    @Override public <T> Val<@Nullable T> valOfNullable(Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner ) {
+    @Override public <T> Val<T> valOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
         Objects.requireNonNull(combiner);
@@ -179,30 +179,30 @@ public final class Sprouts implements SproutsFactory
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type, Val<@Nullable T>... vals ) {
+    @Override public <T> Vals<T> valsOfNullable( Class<T> type, Val<T>... vals ) {
         Var<T>[] vars = new Var[vals.length];
         System.arraycopy(vals, 0, vars, 0, vals.length);
         return AbstractVariables.ofNullable( true, type, vars );
     }
 
-    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type ) {
+    @Override public <T> Vals<T> valsOfNullable( Class<T> type ) {
         return AbstractVariables.ofNullable( true, type );
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<@Nullable T> valsOfNullable( Class<T> type, @Nullable T... items ) {
+    @Override public <T> Vals<T> valsOfNullable( Class<T> type, T... items ) {
         return AbstractVariables.ofNullable( true, type, items );
     }
 
     @SuppressWarnings("unchecked")
-    @Override public <T> Vals<@Nullable T> valsOfNullable( Val<@Nullable T> first, Val<@Nullable T>... rest ) {
+    @Override public <T> Vals<T> valsOfNullable( Val<T> first, Val<T>... rest ) {
         Var<T>[] vars = new Var[rest.length];
         System.arraycopy(rest, 0, vars, 0, rest.length);
         return AbstractVariables.ofNullable( true, (Var<T>) first, vars );
     }
 
     @Override
-    public <T> Vals<@Nullable T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals) {
+    public <T> Vals<T> valsOfNullable(Class<T> type, Vals<T> vals) {
         return AbstractVariables.ofNullable( true, type, vals );
     }
 
@@ -221,19 +221,19 @@ public final class Sprouts implements SproutsFactory
 	@Override public <T> Vars<T> varsOf( Class<T> type, Iterable<Var<T>> vars ) { return AbstractVariables.of( false, type, vars ); }
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type, Var<@Nullable T>... vars ) {
+	@Override public <T> Vars<T> varsOfNullable( Class<T> type, Var<T>... vars ) {
 		return AbstractVariables.ofNullable( false, type, vars );
 	}
 
-	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type ) { return AbstractVariables.ofNullable( false, type ); }
+	@Override public <T> Vars<T> varsOfNullable( Class<T> type ) { return AbstractVariables.ofNullable( false, type ); }
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<@Nullable T> varsOfNullable( Class<T> type, @Nullable T... values ) {
+	@Override public <T> Vars<T> varsOfNullable( Class<T> type, T... values ) {
 		return AbstractVariables.ofNullable( false, type, values );
 	}
 
 	@SuppressWarnings("unchecked")
-	@Override public <T> Vars<@Nullable T> varsOfNullable( Var<@Nullable T> first, Var<@Nullable T>... rest ) {
+	@Override public <T> Vars<T> varsOfNullable( Var<T> first, Var<T>... rest ) {
 		return AbstractVariables.ofNullable( false, first, rest );
 	}
 

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -55,16 +55,16 @@ public interface SproutsFactory
 
 	<T> Vals<T> valsOf( Class<T> type, Vals<T> vals );
 
-	<T> Vals<T> valsOfNullable( Class<T> type );
+	<T> Vals<@Nullable T> valsOfNullable( Class<T> type );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<T> valsOfNullable( Class<T> type, Val<T>... vals );
+	<T> Vals<@Nullable T> valsOfNullable( Class<T> type, Val<@Nullable T>... vals );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<T> valsOfNullable( Class<T> type, T... items );
+	<T> Vals<@Nullable T> valsOfNullable( Class<T> type, @Nullable T... items );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<T> valsOfNullable( Val<T> first, Val<T>... rest );
+	<T> Vals<@Nullable T> valsOfNullable( Val<@Nullable T> first, Val<@Nullable T>... rest );
 
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -81,15 +81,15 @@ public interface SproutsFactory
 	<T> Vars<T> varsOf( Class<T> type, Iterable<Var<T>> vars );
 
 	@SuppressWarnings("unchecked")
-	<T> Vars<T> varsOfNullable( Class<T> type, Var<T>... vars );
+	<T> Vars<@Nullable T> varsOfNullable( Class<T> type, Var<@Nullable T>... vars );
 
-	<T> Vars<T> varsOfNullable( Class<T> type );
-
-	@SuppressWarnings("unchecked")
-	<T> Vars<T> varsOfNullable( Class<T> type, T... values );
+	<T> Vars<@Nullable T> varsOfNullable( Class<T> type );
 
 	@SuppressWarnings("unchecked")
-	<T> Vars<T> varsOfNullable( Var<T> first, Var<T>... rest );
+	<T> Vars<@Nullable T> varsOfNullable( Class<T> type, @Nullable T... values );
+
+	@SuppressWarnings("unchecked")
+	<T> Vars<@Nullable T> varsOfNullable( Var<@Nullable T> first, Var<@Nullable T>... rest );
 
 
 	<V> Result<V> resultOf( Class<V> type );

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -25,11 +25,11 @@ public interface SproutsFactory
 
 	<T> Val<T> valOf( Val<T> toBeCopied );
 
-	<T> Val<T> valOfNullable( Val<T> toBeCopied );
+	<T> Val<@Nullable T> valOfNullable( Val<@Nullable T> toBeCopied );
 
 	<T> Val<T> valOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
-	<T> Val<T> valOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
+	<T> Val<@Nullable T> valOfNullable( Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner );
 
 
 	<T> Var<T> varOfNullable( Class<T> type, @Nullable T item );
@@ -55,16 +55,16 @@ public interface SproutsFactory
 
 	<T> Vals<T> valsOf( Class<T> type, Vals<T> vals );
 
-	<T> Vals<T> valsOfNullable( Class<T> type );
+	<T> Vals<@Nullable T> valsOfNullable( Class<T> type );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<T> valsOfNullable( Class<T> type, Val<T>... vals );
+	<T> Vals<@Nullable T> valsOfNullable( Class<T> type, Val<@Nullable T>... vals );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<T> valsOfNullable( Class<T> type, T... items );
+	<T> Vals<@Nullable T> valsOfNullable( Class<T> type, @Nullable T... items );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<T> valsOfNullable( Val<T> first, Val<T>... rest );
+	<T> Vals<@Nullable T> valsOfNullable( Val<@Nullable T> first, Val<@Nullable T>... rest );
 
 
 	@SuppressWarnings("unchecked")
@@ -81,16 +81,17 @@ public interface SproutsFactory
 	<T> Vars<T> varsOf( Class<T> type, Iterable<Var<T>> vars );
 
 	@SuppressWarnings("unchecked")
-	<T> Vars<T> varsOfNullable( Class<T> type, Var<T>... vars );
+	<T> Vars<@Nullable T> varsOfNullable( Class<T> type, Var<@Nullable T>... vars );
 
-	<T> Vars<T> varsOfNullable( Class<T> type );
-
-	@SuppressWarnings("unchecked")
-	<T> Vars<T> varsOfNullable( Class<T> type, T... values );
+	<T> Vars<@Nullable T> varsOfNullable( Class<T> type );
 
 	@SuppressWarnings("unchecked")
-	<T> Vars<T> varsOfNullable( Var<T> first, Var<T>... rest );
+	<T> Vars<@Nullable T> varsOfNullable( Class<T> type, @Nullable T... values );
 
+	@SuppressWarnings("unchecked")
+	<T> Vars<@Nullable T> varsOfNullable( Var<@Nullable T> first, Var<@Nullable T>... rest );
+
+	<T> Vals<@Nullable T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals);
 
 	<V> Result<V> resultOf( Class<V> type );
 
@@ -114,5 +115,4 @@ public interface SproutsFactory
 
 	<V> Result<List<V>> resultOfList( Class<V> type, List<V> list, List<Problem> problems );
 
-	<T> Vals<T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals);
 }

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -25,11 +25,11 @@ public interface SproutsFactory
 
 	<T> Val<T> valOf( Val<T> toBeCopied );
 
-	<T> Val<@Nullable T> valOfNullable( Val<@Nullable T> toBeCopied );
+	<T> Val<T> valOfNullable( Val<T> toBeCopied );
 
 	<T> Val<T> valOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
-	<T> Val<@Nullable T> valOfNullable( Val<@Nullable T> first, Val<@Nullable T> second, BiFunction<@Nullable T, @Nullable T, @Nullable T> combiner );
+	<T> Val<T> valOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
 
 	<T> Var<T> varOfNullable( Class<T> type, @Nullable T item );
@@ -55,16 +55,16 @@ public interface SproutsFactory
 
 	<T> Vals<T> valsOf( Class<T> type, Vals<T> vals );
 
-	<T> Vals<@Nullable T> valsOfNullable( Class<T> type );
+	<T> Vals<T> valsOfNullable( Class<T> type );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<@Nullable T> valsOfNullable( Class<T> type, Val<@Nullable T>... vals );
+	<T> Vals<T> valsOfNullable( Class<T> type, Val<T>... vals );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<@Nullable T> valsOfNullable( Class<T> type, @Nullable T... items );
+	<T> Vals<T> valsOfNullable( Class<T> type, T... items );
 
 	@SuppressWarnings("unchecked")
-	<T> Vals<@Nullable T> valsOfNullable( Val<@Nullable T> first, Val<@Nullable T>... rest );
+	<T> Vals<T> valsOfNullable( Val<T> first, Val<T>... rest );
 
 
 	@SuppressWarnings("unchecked")
@@ -81,17 +81,16 @@ public interface SproutsFactory
 	<T> Vars<T> varsOf( Class<T> type, Iterable<Var<T>> vars );
 
 	@SuppressWarnings("unchecked")
-	<T> Vars<@Nullable T> varsOfNullable( Class<T> type, Var<@Nullable T>... vars );
+	<T> Vars<T> varsOfNullable( Class<T> type, Var<T>... vars );
 
-	<T> Vars<@Nullable T> varsOfNullable( Class<T> type );
-
-	@SuppressWarnings("unchecked")
-	<T> Vars<@Nullable T> varsOfNullable( Class<T> type, @Nullable T... values );
+	<T> Vars<T> varsOfNullable( Class<T> type );
 
 	@SuppressWarnings("unchecked")
-	<T> Vars<@Nullable T> varsOfNullable( Var<@Nullable T> first, Var<@Nullable T>... rest );
+	<T> Vars<T> varsOfNullable( Class<T> type, T... values );
 
-	<T> Vals<@Nullable T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals);
+	@SuppressWarnings("unchecked")
+	<T> Vars<T> varsOfNullable( Var<T> first, Var<T>... rest );
+
 
 	<V> Result<V> resultOf( Class<V> type );
 
@@ -115,4 +114,5 @@ public interface SproutsFactory
 
 	<V> Result<List<V>> resultOfList( Class<V> type, List<V> list, List<Problem> problems );
 
+	<T> Vals<T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals);
 }

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -114,5 +114,4 @@ public interface SproutsFactory
 
 	<V> Result<List<V>> resultOfList( Class<V> type, List<V> list, List<Problem> problems );
 
-	<T> Vals<T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals);
 }

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -114,4 +114,5 @@ public interface SproutsFactory
 
 	<V> Result<List<V>> resultOfList( Class<V> type, List<V> list, List<Problem> problems );
 
+	<T> Vals<T> valsOfNullable(Class<T> type, Vals<@Nullable T> vals);
 }

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -17,19 +17,19 @@ public interface SproutsFactory
 
 	Event eventOf( Event.Executor executor );
 
-	<T> Val<T> valOfNullable( Class<T> type, @Nullable T item );
+	<T> Val<@Nullable T> valOfNullable( Class<T> type, @Nullable T item );
 
-	<T> Val<T> valOfNull( Class<T> type );
+	<T> Val<@Nullable T> valOfNull( Class<T> type );
 
 	<T> Val<T> valOf( T item );
 
 	<T> Val<T> valOf( Val<T> toBeCopied );
 
-	<T> Val<T> valOfNullable( Val<T> toBeCopied );
+	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> toBeCopied );
 
 	<T> Val<T> valOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
-	<T> Val<T> valOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
+	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
 
 	<T> Var<T> varOfNullable( Class<T> type, @Nullable T item );

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -32,9 +32,9 @@ public interface SproutsFactory
 	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
 
-	<T> Var<T> varOfNullable( Class<T> type, @Nullable T item );
+	<T> Var<@Nullable T> varOfNullable( Class<T> type, @Nullable T item );
 
-	<T> Var<T> varOfNull( Class<T> type );
+	<T> Var<@Nullable T> varOfNull( Class<T> type );
 
 	<T> Var<T> varOf( T item );
 

--- a/src/test/groovy/sprouts/Properties_List_Spec.groovy
+++ b/src/test/groovy/sprouts/Properties_List_Spec.groovy
@@ -836,4 +836,141 @@ class Properties_List_Spec extends Specification
             change.index() == 2
     }
 
+    def 'Properties created by adding values to a property list can be set to `null` if the list allows null properties.'()
+    {
+        given : 'A nullable "Vars" instance having a few properties.'
+            var vars = Vars.ofNullable(String.class, "a", null, "c")
+        expect : 'All properties in the property list are nullable.'
+            vars.at(0).allowsNull()
+            vars.at(1).allowsNull()
+            vars.at(2).allowsNull()
+        when : 'We add a empty property.'
+            vars.add("x")
+        then : 'The property list should contain the added property.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "x")
+        and : 'The added property should also be nullable.'
+            vars.at(3).allowsNull()
+        when : 'We can set the new added property to `null`.'
+            vars.at(3).set(null)
+        then : 'The added property should now be empty'
+            vars.at(3).isEmpty()
+            vars == Vars.ofNullable(String.class, "a", null, "c", null)
+    }
+
+    def 'Properties created by adding values to a property list cannot be set to `null` if the list does not allow null properties.'()
+    {
+        given : 'A "Vars" instance having a few properties.'
+            var vars = Vars.of("a", "b", "x", "d")
+        expect : 'All properties in the property list are not nullable.'
+            !vars.at(0).allowsNull()
+            !vars.at(1).allowsNull()
+            !vars.at(2).allowsNull()
+            !vars.at(3).allowsNull()
+        when : 'We add a property.'
+            vars.add("y")
+        then : 'The property list should contain the added property.'
+            vars == Vars.of("a", "b", "x", "d", "y")
+        and : 'The added property should also be not nullable.'
+            !vars.at(4).allowsNull()
+    }
+
+    def 'You can easily remove properties from a nullable "Vars" list that contains null properties.'() {
+        reportInfo """  
+            A nullable "Vars" list is able to handle null values. So you can remove properties for such a nullable
+            property list.
+        """
+        given: 'A nullable "Vals" instance with a few properties, including null properties.'
+            var vars = Vars.ofNullable(String.class, "a", "b", "c", "d", null, "f", "g", "h", null, "j", "k", "l", "m", "n", "o")
+        when: 'We remove a property with the `remove` method.'
+            vars.remove("d")
+        then: 'The property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "a", "b", "c", null, "f", "g", "h", null, "j", "k", "l", "m", "n", "o")
+        when: 'We remove a property with the `remove` method.'
+            vars.remove(Var.of("m"))
+        then: 'The property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "a", "b", "c", null, "f", "g", "h", null, "j", "k", "l", "n", "o")
+        when: 'We remove a property with the `removeAt` method.'
+            vars.removeAt(1)
+        then: 'The property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "a", "c", null, "f", "g", "h", null, "j", "k", "l", "n", "o")
+        when: 'We remove a property with the `removeFirst` method.'
+            vars.removeFirst()
+        then: 'The property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "c", null, "f", "g", "h", null, "j", "k", "l", "n", "o")
+        when: 'We remove a property with the `removeLast` method.'
+            vars.removeLast()
+        then: 'The property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "c", null, "f", "g", "h", null, "j", "k", "l", "n")
+        when: 'We remove multiple properties with the `removeAll` method.'
+            vars.removeAll("d", "c", "f")
+        then: 'The properties are removed from the property list.'
+            vars == Vars.ofNullable(String.class, null, "g", "h", null, "j", "k", "l", "n")
+        when: 'We remove multiple properties with the `removeFirst` method.'
+            vars.removeFirst(2)
+        then: 'The properties are removed from the property list.'
+            vars == Vars.ofNullable(String.class, "h", null, "j", "k", "l", "n")
+        when: 'We remove multiple properties with the `removeLast` method.'
+            vars.removeLast(2)
+        then: 'The properties are removed from the property list.'
+            vars == Vars.ofNullable(String.class, "h", null, "j", "k")
+    }
+
+    def 'You can easily remove `null` properties from a nullable "Vars" list.'() {
+        reportInfo """  
+            A nullable "Vars" list is able to handle `null` values. So you can remove `null` properties for such a
+            nullable property list.
+        """
+        given: 'A nullable "Vals" instance with a few properties, including `null` properties.'
+            var vars = Vars.ofNullable(String.class, "a", "b", "c", "d", null, null, "g", "h", null, "j", "k", null, "m", null, "o")
+        when: 'We remove an empty (`null`) property with the `remove` method.'
+            vars.remove((String) null)
+        then: 'The `null` property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "a", "b", "c", "d", null, "g", "h", null, "j", "k", null, "m", null, "o")
+        when: 'We remove an empty (`null`) property with the `remove` method.'
+            vars.remove(Var.ofNullable(String.class, null))
+        then: 'The `null` property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "a", "b", "c", "d", "g", "h", null, "j", "k", null, "m", null, "o")
+        when: 'We remove an empty (`null`) property with the `removeAt` method.'
+            vars.removeAt(9)
+        then: 'The `null` property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "a", "b", "c", "d", "g", "h", null, "j", "k", "m", null, "o")
+        when: 'We remove a list of properties including a `null` property with the `removeAll` method.'
+            vars.removeAll(null, "c", "d", "j")
+        then: 'The `null` property is removed from the property list.'
+            vars == Vars.ofNullable(String.class, "a", "b", "g", "h", "k", "m", "o")
+    }
+
+    def 'You can easily add properties to a nullable "Vars" list that contains null properties.'() {
+        reportInfo """  
+            A nullable "Vars" list is able to handle null values. So you can add nullable properties or values to such a
+            nullable property list.
+        """
+        given: 'A nullable "Vals" instance with a few properties, including null properties.'
+            var vars = Vars.ofNullable(String.class, "a", null, "c")
+        when: 'We add a value with the `add` method.'
+            vars.add("d")
+        then: 'The property is added to the property list.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "d")
+        when: 'We add a `null` value with the `add` method.'
+            vars.add(null)
+        then: 'The property is added to the property list.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "d", null)
+        when: 'We add a nullable property with the `add` method.'
+            vars.add(Var.ofNullable(String.class, "f"))
+        then: 'The property is added to the property list.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "d", null, "f")
+        when: 'We add a null property with the `add` method.'
+            vars.add(Var.ofNull(String.class))
+        then: 'The property is added to the property list.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "d", null, "f", null)
+        when: 'We add multiple values with the `addAll` method.'
+            vars.addAll("h1", "h2", null)
+        then: 'The properties are added to the property list.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "d", null, "f", null, "h1", "h2", null)
+        when: 'We add a "Vars" list with the `addAll` method.'
+            vars.addAll(Vars.ofNullable(String.class, null, "i1", "i2"))
+        then: 'The properties are added to the property list.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "d", null, "f", null, "h1", "h2", null, null, "i1", "i2")
+    }
+
 }

--- a/src/test/groovy/sprouts/Properties_List_Spec.groovy
+++ b/src/test/groovy/sprouts/Properties_List_Spec.groovy
@@ -836,42 +836,4 @@ class Properties_List_Spec extends Specification
             change.index() == 2
     }
 
-    def 'Properties created by adding values to a property list can be set to `null` if the list allows null properties.'()
-    {
-        given : 'A nullable "Vars" instance having a few properties.'
-            var vars = Vars.ofNullable(String.class, "a", null, "c")
-        expect : 'All properties in the property list are nullable.'
-            vars.at(0).allowsNull();
-            vars.at(1).allowsNull();
-            vars.at(2).allowsNull();
-        when : 'We add a empty property.'
-            vars.add("x");
-        then : 'The property list should contain the added property.'
-            vars == Vars.ofNullable(String.class, "a", null, "c", "x")
-        and : 'The added property should also be nullable.'
-            vars.at(3).allowsNull()
-        when : 'We can set the new added property to `null`.'
-            vars.at(3).set(null)
-        then : 'The added property should now be empty'
-            vars.at(3).isEmpty()
-            vars == Vars.ofNullable(String.class, "a", null, "c", null)
-    }
-
-    def 'Properties created by adding values to a property list cannot be set to `null` if the list does not allow null properties.'()
-    {
-        given : 'A "Vars" instance having a few properties.'
-            var vars = Vars.of("a", "b", "x", "d")
-        expect : 'All properties in the property list are not nullable.'
-            !vars.at(0).allowsNull();
-            !vars.at(1).allowsNull();
-            !vars.at(2).allowsNull();
-            !vars.at(3).allowsNull();
-        when : 'We add a property.'
-            vars.add("y");
-        then : 'The property list should contain the added property.'
-            vars == Vars.of("a", "b", "x", "d", "y")
-        and : 'The added property should also be not nullable.'
-            !vars.at(4).allowsNull()
-    }
-
 }

--- a/src/test/groovy/sprouts/Properties_List_Spec.groovy
+++ b/src/test/groovy/sprouts/Properties_List_Spec.groovy
@@ -836,4 +836,42 @@ class Properties_List_Spec extends Specification
             change.index() == 2
     }
 
+    def 'Properties created by adding values to a property list can be set to `null` if the list allows null properties.'()
+    {
+        given : 'A nullable "Vars" instance having a few properties.'
+            var vars = Vars.ofNullable(String.class, "a", null, "c")
+        expect : 'All properties in the property list are nullable.'
+            vars.at(0).allowsNull();
+            vars.at(1).allowsNull();
+            vars.at(2).allowsNull();
+        when : 'We add a empty property.'
+            vars.add("x");
+        then : 'The property list should contain the added property.'
+            vars == Vars.ofNullable(String.class, "a", null, "c", "x")
+        and : 'The added property should also be nullable.'
+            vars.at(3).allowsNull()
+        when : 'We can set the new added property to `null`.'
+            vars.at(3).set(null)
+        then : 'The added property should now be empty'
+            vars.at(3).isEmpty()
+            vars == Vars.ofNullable(String.class, "a", null, "c", null)
+    }
+
+    def 'Properties created by adding values to a property list cannot be set to `null` if the list does not allow null properties.'()
+    {
+        given : 'A "Vars" instance having a few properties.'
+            var vars = Vars.of("a", "b", "x", "d")
+        expect : 'All properties in the property list are not nullable.'
+            !vars.at(0).allowsNull();
+            !vars.at(1).allowsNull();
+            !vars.at(2).allowsNull();
+            !vars.at(3).allowsNull();
+        when : 'We add a property.'
+            vars.add("y");
+        then : 'The property list should contain the added property.'
+            vars == Vars.of("a", "b", "x", "d", "y")
+        and : 'The added property should also be not nullable.'
+            !vars.at(4).allowsNull()
+    }
+
 }


### PR DESCRIPTION
I added `@Nullable` annotations and updated the documentation accordingly. I also found edge cases that were not handled correctly.

For example, when adding a value to a property list. The new property was always created with the `.of(T value)` methods, even though the property list allowed nullables.