### PR TITLE
29 support for different types of composite property views

### DIFF
--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -219,10 +219,12 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @param combiner The function used to combine the items of the two properties,
 	 *                 where the first argument is the item of the first property and
 	 *                 the second argument is the item of the second property.
-	 * @param <T>      The type of the items held by the properties.
+	 * @param <T>      The type of the first property.
+	 * @param <U>      The type of the second property.
+	 * @param <R>      The type of the returned property.
 	 * @return A new {@link Val} instance which is a live view of the two given properties.
-	 * @throws NullPointerException     If the combiner function returns a {@code null} reference
-	 *                                  <b>when it is first called</b>.
+	 * @throws NullPointerException If the combiner function returns a {@code null} reference
+	 *                              <b>when it is first called</b>.
 	 */
 	static <T extends @Nullable Object, U extends @Nullable Object, R> Val<R> viewOf(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, R> combiner ) {
 		Objects.requireNonNull(type);
@@ -252,7 +254,9 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @param combiner The function used to combine the items of the two properties,
 	 *                 where the first argument is the item of the first property and
 	 *                 the second argument is the item of the second property.
-	 * @param <T>      The type of the items held by the properties.
+	 * @param <T>      The type of the first property.
+	 * @param <U>      The type of the second property.
+	 * @param <R>      The type of the returned property.
 	 * @return A new {@link Val} instance which is a live view of the two given properties.
 	 */
 	static <T extends @Nullable Object, U extends @Nullable Object, R> Val<@Nullable R> viewOfNullable(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, @Nullable R> combiner ) {

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -242,6 +242,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * on either of the two properties.
 	 * <p>
 	 * Note: The property view does <b>allow</b> storing {@code null} references!
+	 * If the combiner function throws an exception, the view will be set to {@code null}.
 	 * <p>
 	 * If you need a composite view that not allows {@code null}, use the {@link #viewOf(Class, Val, Val, BiFunction)}
 	 * method instead.

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -136,8 +136,8 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * on either of the two properties.
 	 * <p>
 	 * Note: The property view does <b>not</b> allow storing {@code null} references!
-	 * So if the combiner function returns a {@code null} reference on the first call, a {@link NullPointerException}
-	 * will be thrown.
+	 * So if the combiner function returns a {@code null} reference or throws an exception on the first call,
+	 * a {@link NullPointerException} will be thrown.
 	 * If a {@code null} reference is returned on subsequent calls, the view will log a warning and simply retain the
 	 * last non-null value!
 	 * <p>
@@ -172,6 +172,8 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * on either of the two properties.
 	 * <p>
 	 * Note: The property view does <b>allow</b> storing {@code null} references!
+	 * If the combiner function throws an exception, the view will be set to {@code null}.
+	 * <p>
 	 * If you need a composite view that not allows {@code null}, use the {@link #viewOf(Val, Val, BiFunction)}
 	 * method instead.
 	 *
@@ -188,8 +190,6 @@ public interface Val<T extends @Nullable Object> extends Observable {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);
-		if ( first.type() != second.type() )
-			throw new IllegalArgumentException("The types of the two properties are not compatible!");
 		return Sprouts.factory().viewOfNullable( first, second, combiner );
 	}
 

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -127,71 +127,73 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	}
 
 	/**
-	 *  Creates a read only {@link Val} property that constitutes a live view of
-	 *  the two given properties using a combiner function, which takes in the
-	 *  items of the two properties and returns an updated item based on them. <br>
-	 *  The combiner function is invoked to compute a new item for the view property whenever
-	 *  at least one of the items in the two properties changes, or
-	 *  whenever a manual change event is fired (see {@link Var#fireChange(Channel)}) on
-	 *  either one... <br><br>
-	 *  <p>
-	 *  <b>Note the property view does not permit storing null references!
-	 *  So if the combiner function returns a null reference on the first call,
-	 *  a {@link NullPointerException} will be thrown.
-	 *  If a null reference is returned on subsequent calls, the view will
-	 *  log a warning and simply retain the last non-null value!</b><br>
-	 *  If you need a composite view which allows null, use the {@link #ofNullable(Val, Val, BiFunction)} method instead.
+	 * Creates a read-only {@link Val} property that represents a live view of the two given properties using a
+	 * combiner function.
+	 * <p>
+	 * The combiner function takes the items of the two properties and returns an updated item based on them.
+	 * The combiner is called to compute a new item for the view property whenever at least one of the items
+	 * in the two properties changes, or whenever a manual change event is fired (see {@link Var#fireChange(Channel)})
+	 * on either of the two properties.
+	 * <p>
+	 * Note: The property view does <b>not</b> allow storing {@code null} references!
+	 * So if the combiner function returns a {@code null} reference on the first call, a {@link NullPointerException}
+	 * will be thrown.
+	 * If a {@code null} reference is returned on subsequent calls, the view will log a warning and simply retain the
+	 * last non-null value!
+	 * <p>
+	 * If you need a composite view that allows {@code null}, use the {@link #viewOfNullable(Val, Val, BiFunction)}
+	 * method instead.
 	 *
-	 * @param first The first property to be combined with the second property.
-	 * @param second The second property to be combined with the first property.
+	 * @param first    The first property to be combined.
+	 * @param second   The second property to be combined.
 	 * @param combiner The function used to combine the items of the two properties,
 	 *                 where the first argument is the item of the first property and
 	 *                 the second argument is the item of the second property.
+	 * @param <T>      The type of the items held by the properties.
 	 * @return A new {@link Val} instance which is a live view of the two given properties.
-	 * @param <T> The type of the items held by the properties.
-	 * @throws NullPointerException If the combiner function returns a null reference
-	 *                              <b>when it is first called</b>.
+	 * @throws NullPointerException     If the combiner function returns a {@code null} reference
+	 *                                  <b>when it is first called</b>.
 	 * @throws IllegalArgumentException If the types of the two properties are not compatible.
 	 */
-	static <T> Val<T> of( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	static <T> Val<T> viewOf(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);
 		if ( first.type() != second.type() )
 			throw new IllegalArgumentException("The types of the two properties are not compatible!");
-		return Sprouts.factory().valOf( first, second, combiner );
+		return Sprouts.factory().viewOf( first, second, combiner );
 	}
 
 	/**
-	 *  Creates a read only {@link Val} property that constitutes a live view of
-	 *  the two given properties using a combiner function, which takes in the
-	 *  items of the two properties and returns an updated item based on them. <br>
-	 *  The combiner function is invoked to compute a new item for the view property whenever
-	 *  at least one of the items of the two properties change, or
-	 *  whenever a manual change event is fired (see {@link Var#fireChange(Channel)}). <br><br>
-	 *  <p>
-	 *  <b>Note that this property does permit storing null references.</b><br>
-	 *  If you need a composite view which does not permit null,
-	 *  use the {@link #of(Val, Val, BiFunction)} method instead.
+	 * Creates a read-only nullable {@link Val} property that represents a live view of the two given properties using a
+	 * combiner function.
+	 * <p>
+	 * The combiner function takes the items of the two properties and returns an updated item based on them.
+	 * The combiner is called to compute a new item for the view property whenever at least one of the items
+	 * in the two properties changes, or whenever a manual change event is fired (see {@link Var#fireChange(Channel)})
+	 * on either of the two properties.
+	 * <p>
+	 * Note: The property view does <b>allow</b> storing {@code null} references!
+	 * If you need a composite view that not allows {@code null}, use the {@link #viewOf(Val, Val, BiFunction)}
+	 * method instead.
 	 *
-	 * @param first The first property to be combined with the second property.
-	 * @param second The second property to be combined with the first property.
+	 * @param first    The first property to be combined.
+	 * @param second   The second property to be combined.
 	 * @param combiner The function used to combine the items of the two properties,
 	 *                 where the first argument is the item of the first property and
 	 *                 the second argument is the item of the second property.
-	 * @return A new {@link Val} instance which is a live view of the two given properties.
-	 * @param <T> The type of the items held by the properties.
-	 * @throws NullPointerException If the combiner function returns a null reference
-	 *                              <b>when it is first called</b>.
+	 * @param <T>      The type of the items held by the properties.
+	 * @return A new nullable {@link Val} instance which is a live view of the two given properties.
 	 * @throws IllegalArgumentException If the types of the two properties are not compatible.
 	 */
-	static <T extends @Nullable Object> Val<@Nullable T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	static <T extends @Nullable Object> Val<@Nullable T> viewOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);
 		if ( first.type() != second.type() )
 			throw new IllegalArgumentException("The types of the two properties are not compatible!");
 		return Sprouts.factory().valOfNullable( first, second, combiner );
+		return Sprouts.factory().viewOfNullable( first, second, combiner );
 	}
 
 	/**

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -174,7 +174,7 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * Note: The property view does <b>allow</b> storing {@code null} references!
 	 * If the combiner function throws an exception, the view will be set to {@code null}.
 	 * <p>
-	 * If you need a composite view that not allows {@code null}, use the {@link #viewOf(Val, Val, BiFunction)}
+	 * If you need a composite view that does not allow {@code null}, use the {@link #viewOf(Val, Val, BiFunction)}
 	 * method instead.
 	 *
 	 * @param first    The first property to be combined.

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -192,8 +192,75 @@ public interface Val<T extends @Nullable Object> extends Observable {
 		Objects.requireNonNull(combiner);
 		if ( first.type() != second.type() )
 			throw new IllegalArgumentException("The types of the two properties are not compatible!");
-		return Sprouts.factory().valOfNullable( first, second, combiner );
 		return Sprouts.factory().viewOfNullable( first, second, combiner );
+	}
+
+	/**
+	 * Creates a read-only {@link Val} property that represents a live view of the two given properties using a
+	 * combiner function.
+	 * <p>
+	 * The combiner function takes the items of the two properties and returns an updated item based on them.
+	 * The combiner is called to compute a new item for the view property whenever at least one of the items
+	 * in the two properties changes, or whenever a manual change event is fired (see {@link Var#fireChange(Channel)})
+	 * on either of the two properties.
+	 * <p>
+	 * Note: The property view does <b>not</b> allow storing {@code null} references!
+	 * So if the combiner function returns a {@code null} reference on the first call, a {@link NullPointerException}
+	 * will be thrown.
+	 * If a {@code null} reference is returned on subsequent calls, the view will log a warning and simply retain the
+	 * last non-null value!
+	 * <p>
+	 * If you need a composite view that allows {@code null}, use the {@link #viewOfNullable(Class, Val, Val, BiFunction)}
+	 * method instead.
+	 *
+	 * @param type     The type of the item returned from the mapping function.
+	 * @param first    The first property to be combined.
+	 * @param second   The second property to be combined.
+	 * @param combiner The function used to combine the items of the two properties,
+	 *                 where the first argument is the item of the first property and
+	 *                 the second argument is the item of the second property.
+	 * @param <T>      The type of the items held by the properties.
+	 * @return A new {@link Val} instance which is a live view of the two given properties.
+	 * @throws NullPointerException     If the combiner function returns a {@code null} reference
+	 *                                  <b>when it is first called</b>.
+	 */
+	static <T extends @Nullable Object, U extends @Nullable Object, R> Val<R> viewOf(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, R> combiner ) {
+		Objects.requireNonNull(type);
+		Objects.requireNonNull(first);
+		Objects.requireNonNull(second);
+		Objects.requireNonNull(combiner);
+		return Sprouts.factory().viewOf( type, first, second, combiner );
+	}
+
+	/**
+	 * Creates a read-only nullable {@link Val} property that represents a live view of the two given properties using a
+	 * combiner function.
+	 * <p>
+	 * The combiner function takes the items of the two properties and returns an updated item based on them.
+	 * The combiner is called to compute a new item for the view property whenever at least one of the items
+	 * in the two properties changes, or whenever a manual change event is fired (see {@link Var#fireChange(Channel)})
+	 * on either of the two properties.
+	 * <p>
+	 * Note: The property view does <b>allow</b> storing {@code null} references!
+	 * <p>
+	 * If you need a composite view that not allows {@code null}, use the {@link #viewOf(Class, Val, Val, BiFunction)}
+	 * method instead.
+	 *
+	 * @param type     The type of the item returned from the mapping function.
+	 * @param first    The first property to be combined.
+	 * @param second   The second property to be combined.
+	 * @param combiner The function used to combine the items of the two properties,
+	 *                 where the first argument is the item of the first property and
+	 *                 the second argument is the item of the second property.
+	 * @param <T>      The type of the items held by the properties.
+	 * @return A new {@link Val} instance which is a live view of the two given properties.
+	 */
+	static <T extends @Nullable Object, U extends @Nullable Object, R> Val<@Nullable R> viewOfNullable(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, @Nullable R> combiner ) {
+		Objects.requireNonNull(type);
+		Objects.requireNonNull(first);
+		Objects.requireNonNull(second);
+		Objects.requireNonNull(combiner);
+		return Sprouts.factory().viewOfNullable( type, first, second, combiner );
 	}
 
 	/**

--- a/src/main/java/sprouts/Val.java
+++ b/src/main/java/sprouts/Val.java
@@ -149,18 +149,16 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @param combiner The function used to combine the items of the two properties,
 	 *                 where the first argument is the item of the first property and
 	 *                 the second argument is the item of the second property.
-	 * @param <T>      The type of the items held by the properties.
+	 * @param <T>      The type of the item of the first property and the returned property.
+	 * @param <U>      The type of the second property.
 	 * @return A new {@link Val} instance which is a live view of the two given properties.
-	 * @throws NullPointerException     If the combiner function returns a {@code null} reference
-	 *                                  <b>when it is first called</b>.
-	 * @throws IllegalArgumentException If the types of the two properties are not compatible.
+	 * @throws NullPointerException If the combiner function returns a {@code null} reference
+	 *                              <b>when it is first called</b>.
 	 */
-	static <T> Val<T> viewOf(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	static <T extends @Nullable Object, U extends @Nullable Object> Val<@NonNull T> viewOf(Val<T> first, Val<U> second, BiFunction<T, U, @NonNull T> combiner ) {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);
-		if ( first.type() != second.type() )
-			throw new IllegalArgumentException("The types of the two properties are not compatible!");
 		return Sprouts.factory().viewOf( first, second, combiner );
 	}
 
@@ -182,11 +180,11 @@ public interface Val<T extends @Nullable Object> extends Observable {
 	 * @param combiner The function used to combine the items of the two properties,
 	 *                 where the first argument is the item of the first property and
 	 *                 the second argument is the item of the second property.
-	 * @param <T>      The type of the items held by the properties.
+	 * @param <T>      The type of the item of the first property and the returned property.
+	 * @param <U>      The type of the second property.
 	 * @return A new nullable {@link Val} instance which is a live view of the two given properties.
-	 * @throws IllegalArgumentException If the types of the two properties are not compatible.
 	 */
-	static <T extends @Nullable Object> Val<@Nullable T> viewOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	static <T extends @Nullable Object, U extends @Nullable Object> Val<@Nullable T> viewOfNullable(Val<T> first, Val<U> second, BiFunction<T, U, @Nullable T> combiner ) {
 		Objects.requireNonNull(first);
 		Objects.requireNonNull(second);
 		Objects.requireNonNull(combiner);

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -35,11 +35,11 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 		return new AbstractVariable<T>( immutable, (Class<T>) iniValue.getClass(), iniValue, NO_ID, Collections.emptyMap(), false );
 	}
 
-	public static <T> Var<T> viewOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	public static <T extends @Nullable Object, U extends @Nullable Object> Var<@NonNull T> viewOf( Val<T> first, Val<U> second, BiFunction<T, U, @NonNull T> combiner ) {
 		return of( false, first, second, combiner );
 	}
 
-	public static <T extends @Nullable Object> Var<@Nullable T> viewOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	public static <T extends @Nullable Object, U extends @Nullable Object> Var<@Nullable T> viewOfNullable( Val<T> first, Val<U> second, BiFunction<T, U, @Nullable T> combiner ) {
 		return of( true, first, second, combiner );
 	}
 
@@ -51,7 +51,7 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 		return ofNullable( type, first, second, combiner );
 	}
 
-	private static <T extends @Nullable Object> Var<T> of( boolean allowNull, Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	private static <T extends @Nullable Object, U extends @Nullable Object> Var<T> of( boolean allowNull, Val<T> first, Val<U> second, BiFunction<T, U, T> combiner ) {
 		String id = "";
 		if ( !first.id().isEmpty() && !second.id().isEmpty() )
 			id = first.id() + "_and_" + second.id();
@@ -60,7 +60,7 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 		else if ( !second.id().isEmpty() )
 			id = second.id();
 
-		BiFunction<Val<T>, Val<T>, T> fullCombiner = (p1, p2) -> {
+		BiFunction<Val<T>, Val<U>, T> fullCombiner = (p1, p2) -> {
 			@Nullable T newItem = null;
 			try {
 				newItem = combiner.apply(p1.orElseNull(), p2.orElseNull());

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -36,11 +36,11 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 	}
 
 	public static <T extends @Nullable Object, U extends @Nullable Object> Var<@NonNull T> viewOf( Val<T> first, Val<U> second, BiFunction<T, U, @NonNull T> combiner ) {
-		return of( false, first, second, combiner );
+		return of( first, second, combiner );
 	}
 
 	public static <T extends @Nullable Object, U extends @Nullable Object> Var<@Nullable T> viewOfNullable( Val<T> first, Val<U> second, BiFunction<T, U, @Nullable T> combiner ) {
-		return of( true, first, second, combiner );
+		return ofNullable( first, second, combiner );
 	}
 
 	public static <T extends @Nullable Object, U extends @Nullable Object, R> Val<R> viewOf(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, R> combiner) {
@@ -51,7 +51,7 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 		return ofNullable( type, first, second, combiner );
 	}
 
-	private static <T extends @Nullable Object, U extends @Nullable Object> Var<T> of( boolean allowNull, Val<T> first, Val<U> second, BiFunction<T, U, T> combiner ) {
+	private static <T extends @Nullable Object, U extends @Nullable Object> Var<@NonNull T> of( Val<T> first, Val<U> second, BiFunction<T, U, @NonNull T> combiner ) {
 		String id = "";
 		if ( !first.id().isEmpty() && !second.id().isEmpty() )
 			id = first.id() + "_and_" + second.id();
@@ -60,46 +60,59 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 		else if ( !second.id().isEmpty() )
 			id = second.id();
 
-		BiFunction<Val<T>, Val<U>, T> fullCombiner = (p1, p2) -> {
-			@Nullable T newItem = null;
+		BiFunction<Val<T>, Val<U>, @Nullable T> fullCombiner = (p1, p2) -> {
 			try {
-				newItem = combiner.apply(p1.orElseNull(), p2.orElseNull());
+				return combiner.apply(p1.orElseNull(), p2.orElseNull());
 			} catch ( Exception e ) {
-				if ( !allowNull ) {
-					newItem = _itemNullObjectOrNullOf(p1.type(), newItem);
-				}
-				if ( newItem == null )
-					throw new NullPointerException(
-							"Failed to initialize this non-nullable property with the initial value " +
-									"due to the result of the combiner function not yielding a non-null value!"
-					);
-				e.printStackTrace();
+				return null;
 			}
+		};
 
-			if ( !allowNull && newItem == null ) {
-				newItem = _itemNullObjectOrNullOf(first.type(), newItem);
-				if ( newItem == null )
-					throw new NullPointerException("The result of the combiner function is null, but the property does not allow null values!");
+		T initial = fullCombiner.apply(first, second);
+		Objects.requireNonNull(initial,"The result of the combiner function is null, but the property does not allow null values!");
+
+		Var<T> result = AbstractVariable.of( false, first.type(), initial ).withId(id);
+
+		first.onChange(From.ALL, v -> {
+			T newItem = fullCombiner.apply(v, second);
+			if (newItem == null)
+				log.error("Invalid combiner result! The combination of the first value '{}' (changed) and the second value '{}' was null and null is not allowed! The old value '{}' is retained!", first.orElseNull(), second.orElseNull(), result.orElseNull());
+			else
+				result.set(From.ALL, newItem);
+		});
+		second.onChange(From.ALL, v -> {
+			T newItem = fullCombiner.apply(first, v);
+			if (newItem == null)
+				log.error("Invalid combiner result! The combination of the first value '{}' and the second value '{}' (changed) was null and null is not allowed! The old value '{}' is retained!", first.orElseNull(), second.orElseNull(), result.orElseNull());
+			else
+				result.set(From.ALL, newItem);
+		});
+		return result;
+	}
+
+	private static <T extends @Nullable Object, U extends @Nullable Object> Var<T> ofNullable( Val<T> first, Val<U> second, BiFunction<T, U, T> combiner ) {
+		String id = "";
+		if ( !first.id().isEmpty() && !second.id().isEmpty() )
+			id = first.id() + "_and_" + second.id();
+		else if ( !first.id().isEmpty() )
+			id = first.id();
+		else if ( !second.id().isEmpty() )
+			id = second.id();
+
+		BiFunction<Val<T>, Val<U>, @Nullable T> fullCombiner = (p1, p2) -> {
+			try {
+				return combiner.apply(p1.orElseNull(), p2.orElseNull());
+			} catch ( Exception e ) {
+				return null;
 			}
-			return newItem;
 		};
 
 		T initial = fullCombiner.apply(first, second);
 
-		Var<T> result;
-		if ( allowNull )
-			result = AbstractVariable.ofNullable( false, first.type(), initial ).withId(id);
-		else
-			result = AbstractVariable.of( false, first.type(), initial ).withId(id);
+		Var<@Nullable T> result = AbstractVariable.ofNullable( false, first.type(), initial ).withId(id);
 
-		first.onChange(From.ALL, v -> {
-			T newItem = fullCombiner.apply(v, second);
-			result.set(From.ALL, newItem);
-		});
-		second.onChange(From.ALL, v -> {
-			T newItem = fullCombiner.apply(first, v);
-			result.set(From.ALL, newItem);
-		});
+		first.onChange(From.ALL, v -> result.set(From.ALL, fullCombiner.apply(v, second)));
+		second.onChange(From.ALL, v -> result.set(From.ALL, fullCombiner.apply(first, v)));
 		return result;
 	}
 
@@ -161,14 +174,10 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 			}
 		};
 
-		Var<R> result =  AbstractVariable.ofNullable( false, type, fullCombiner.apply(first, second) ).withId(id);
+		Var<@Nullable R> result =  AbstractVariable.ofNullable( false, type, fullCombiner.apply(first, second) ).withId(id);
 
-		first.onChange(From.ALL, v -> {
-				result.set(From.ALL, fullCombiner.apply(v, second));
-		});
-		second.onChange(From.ALL, v -> {
-				result.set(From.ALL, fullCombiner.apply(first, v));
-		});
+		first.onChange(From.ALL, v -> result.set(From.ALL, fullCombiner.apply(v, second)));
+		second.onChange(From.ALL, v -> result.set(From.ALL, fullCombiner.apply(first, v)));
 		return result;
 	}
 

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -32,11 +32,11 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 		return new AbstractVariable<T>( immutable, (Class<T>) iniValue.getClass(), iniValue, NO_ID, Collections.emptyMap(), false );
 	}
 
-	public static <T> Var<T> of( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	public static <T> Var<T> viewOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		return of( false, first, second, combiner );
 	}
 
-	public static <T extends @Nullable Object> Var<@Nullable T> ofNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+	public static <T extends @Nullable Object> Var<@Nullable T> viewOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		return of( true, first, second, combiner );
 	}
 

--- a/src/main/java/sprouts/impl/AbstractVariable.java
+++ b/src/main/java/sprouts/impl/AbstractVariable.java
@@ -2,6 +2,7 @@ package sprouts.impl;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
 import sprouts.Observable;
 import sprouts.Observer;
 import sprouts.*;
@@ -19,6 +20,8 @@ import java.util.function.Function;
  * @param <T> The type of the value wrapped by a given property...
  */
 public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<T> implements Var<T> {
+	private static final Logger log = org.slf4j.LoggerFactory.getLogger(AbstractVariable.class);
+
 	public static <T> Var<@Nullable T> ofNullable( boolean immutable, Class<T> type, @Nullable T value ) {
 		return new AbstractVariable<T>( immutable, type, value, NO_ID, Collections.emptyMap(), true );
 	}
@@ -38,6 +41,14 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 
 	public static <T extends @Nullable Object> Var<@Nullable T> viewOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
 		return of( true, first, second, combiner );
+	}
+
+	public static <T extends @Nullable Object, U extends @Nullable Object, R> Val<R> viewOf(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, R> combiner) {
+		return of( type, first, second, combiner );
+	}
+
+	public static <T extends @Nullable Object, U extends @Nullable Object, R> Val<@Nullable R> viewOfNullable(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, @Nullable R> combiner) {
+		return ofNullable( type, first, second, combiner );
 	}
 
 	private static <T extends @Nullable Object> Var<T> of( boolean allowNull, Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
@@ -88,6 +99,75 @@ public class AbstractVariable<T extends @Nullable Object> extends AbstractValue<
 		second.onChange(From.ALL, v -> {
 			T newItem = fullCombiner.apply(first, v);
 			result.set(From.ALL, newItem);
+		});
+		return result;
+	}
+
+	private static <T extends @Nullable Object, U extends @Nullable Object, R> Val<R> of(Class<R> type, Val<T> first, Val<U> second, BiFunction<T,U,R> combiner) {
+		String id = "";
+		if ( !first.id().isEmpty() && !second.id().isEmpty() )
+			id = first.id() + "_and_" + second.id();
+		else if ( !first.id().isEmpty() )
+			id = first.id();
+		else if ( !second.id().isEmpty() )
+			id = second.id();
+
+		BiFunction<Val<T>, Val<U>, @Nullable R> fullCombiner = (p1, p2) -> {
+			try {
+				return combiner.apply(p1.orElseNull(), p2.orElseNull());
+			} catch ( Exception e ) {
+				return null;
+			}
+		};
+
+		@Nullable R initial = fullCombiner.apply(first, second);
+
+		if (initial == null)
+			throw new NullPointerException("The result of the combiner function is null, but the property does not allow null values!");
+
+		Var<R> result = AbstractVariable.of( false, type, initial ).withId(id);
+
+		first.onChange(From.ALL, v -> {
+			@Nullable R newItem = fullCombiner.apply(v, second);
+			if (newItem == null)
+				log.error("Invalid combiner result! The combination of the first value '{}' (changed) and the second value '{}' was null and null is not allowed! The old value '{}' is retained!", first.orElseNull(), second.orElseNull(), result.orElseNull());
+			else
+				result.set(From.ALL, newItem);
+		});
+		second.onChange(From.ALL, v -> {
+			@Nullable R newItem = fullCombiner.apply(first, v);
+			if (newItem == null)
+				log.error("Invalid combiner result! The combination of the first value '{}' and the second value '{}' (changed) was null and null is not allowed! The old value '{}' is retained!", first.orElseNull(), second.orElseNull(), result.orElseNull());
+			else
+				result.set(From.ALL, newItem);
+		});
+		return result;
+	}
+
+	private static <T extends @Nullable Object, U extends @Nullable Object, R> Val<@Nullable R> ofNullable(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, @Nullable R> combiner) {
+		String id = "";
+		if ( !first.id().isEmpty() && !second.id().isEmpty() )
+			id = first.id() + "_and_" + second.id();
+		else if ( !first.id().isEmpty() )
+			id = first.id();
+		else if ( !second.id().isEmpty() )
+			id = second.id();
+
+		BiFunction<Val<T>, Val<U>, @Nullable R> fullCombiner = (p1, p2) -> {
+			try {
+				return combiner.apply(p1.orElseNull(), p2.orElseNull());
+			} catch ( Exception e ) {
+				return null;
+			}
+		};
+
+		Var<R> result =  AbstractVariable.ofNullable( false, type, fullCombiner.apply(first, second) ).withId(id);
+
+		first.onChange(From.ALL, v -> {
+				result.set(From.ALL, fullCombiner.apply(v, second));
+		});
+		second.onChange(From.ALL, v -> {
+				result.set(From.ALL, fullCombiner.apply(first, v));
 		});
 		return result;
 	}

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -132,8 +132,25 @@ public final class Sprouts implements SproutsFactory
         Objects.requireNonNull(combiner);
         if ( first.type() != second.type() )
             throw new IllegalArgumentException("The types of the two properties are not compatible!");
-        return AbstractVariable.ofNullable( first, second, combiner );
         return AbstractVariable.viewOfNullable( first, second, combiner );
+    }
+
+    @Override
+    public <T extends @Nullable Object, U extends @Nullable Object, R> Val<R> viewOf(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, R> combiner) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(first);
+        Objects.requireNonNull(second);
+        Objects.requireNonNull(combiner);
+        return AbstractVariable.viewOf( type, first, second, combiner );
+    }
+
+    @Override
+    public <T extends @Nullable Object, U extends @Nullable Object, R> Val<@Nullable R> viewOfNullable(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, @Nullable R> combiner) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(first);
+        Objects.requireNonNull(second);
+        Objects.requireNonNull(combiner);
+        return AbstractVariable.viewOfNullable( type, first, second, combiner );
     }
 
 

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -117,22 +117,23 @@ public final class Sprouts implements SproutsFactory
         return Val.ofNullable( toBeCopied.type(), toBeCopied.orElseNull() ).withId( toBeCopied.id() );
     }
 
-    @Override public <T> Val<T> valOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+    @Override public <T> Val<T> viewOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
         Objects.requireNonNull(combiner);
         if ( first.type() != second.type() )
             throw new IllegalArgumentException("The types of the two properties are not compatible!");
-        return AbstractVariable.of( first, second, combiner );
+        return AbstractVariable.viewOf( first, second, combiner );
     }
 
-    @Override public <T extends @Nullable Object> Val<@Nullable T> valOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+    @Override public <T extends @Nullable Object> Val<@Nullable T> viewOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
         Objects.requireNonNull(combiner);
         if ( first.type() != second.type() )
             throw new IllegalArgumentException("The types of the two properties are not compatible!");
         return AbstractVariable.ofNullable( first, second, combiner );
+        return AbstractVariable.viewOfNullable( first, second, combiner );
     }
 
 

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -1,5 +1,6 @@
 package sprouts.impl;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import sprouts.*;
 
@@ -117,21 +118,19 @@ public final class Sprouts implements SproutsFactory
         return Val.ofNullable( toBeCopied.type(), toBeCopied.orElseNull() ).withId( toBeCopied.id() );
     }
 
-    @Override public <T> Val<T> viewOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+    @Override
+    public <T extends @Nullable Object, U extends @Nullable Object> Val<@NonNull T> viewOf(Val<T> first, Val<U> second, BiFunction<T, U, @NonNull T> combiner ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
         Objects.requireNonNull(combiner);
-        if ( first.type() != second.type() )
-            throw new IllegalArgumentException("The types of the two properties are not compatible!");
         return AbstractVariable.viewOf( first, second, combiner );
     }
 
-    @Override public <T extends @Nullable Object> Val<@Nullable T> viewOfNullable(Val<T> first, Val<T> second, BiFunction<T, T, T> combiner ) {
+    @Override
+    public <T extends @Nullable Object, U extends @Nullable Object> Val<@Nullable T> viewOfNullable(Val<T> first, Val<U> second, BiFunction<T, U, @Nullable T> combiner ) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
         Objects.requireNonNull(combiner);
-        if ( first.type() != second.type() )
-            throw new IllegalArgumentException("The types of the two properties are not compatible!");
         return AbstractVariable.viewOfNullable( first, second, combiner );
     }
 

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -28,6 +28,9 @@ public interface SproutsFactory
 	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> toBeCopied );
 
 	<T> Val<T> valOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
+	<T> Val<T> viewOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
+
+	<T extends @Nullable Object> Val<@Nullable T> viewOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
 	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -1,5 +1,6 @@
 package sprouts.impl;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import sprouts.*;
 
@@ -27,9 +28,9 @@ public interface SproutsFactory
 
 	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> toBeCopied );
 
-	<T> Val<T> viewOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
+	<T extends @Nullable Object, U extends @Nullable Object> Val<@NonNull T> viewOf(Val<T> first, Val<U> second, BiFunction<T, U, @NonNull T> combiner );
 
-	<T extends @Nullable Object> Val<@Nullable T> viewOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
+	<T extends @Nullable Object, U extends @Nullable Object> Val<@Nullable T> viewOfNullable( Val<T> first, Val<U> second, BiFunction<T, U, @Nullable T> combiner );
 
 	<T extends @Nullable Object, U extends @Nullable Object, R> Val<R> viewOf(Class<R> type, Val<T> first, Val<U> second, BiFunction<T,U,R> combiner);
 

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -27,12 +27,13 @@ public interface SproutsFactory
 
 	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> toBeCopied );
 
-	<T> Val<T> valOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 	<T> Val<T> viewOf( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
 	<T extends @Nullable Object> Val<@Nullable T> viewOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
 
-	<T extends @Nullable Object> Val<@Nullable T> valOfNullable( Val<T> first, Val<T> second, BiFunction<T, T, T> combiner );
+	<T extends @Nullable Object, U extends @Nullable Object, R> Val<R> viewOf(Class<R> type, Val<T> first, Val<U> second, BiFunction<T,U,R> combiner);
+
+	<T extends @Nullable Object, U extends @Nullable Object, R> Val<@Nullable R> viewOfNullable(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, @Nullable R> combiner);
 
 
 	<T> Var<@Nullable T> varOfNullable( Class<T> type, @Nullable T item );

--- a/src/test/groovy/sprouts/Composite_Properties_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_Properties_Spec.groovy
@@ -31,7 +31,7 @@ class Composite_Properties_Spec extends Specification
             Var<String> forename = Var.of("John")
             Var<String> surname = Var.of("Doe")
         and : 'Now we create a view of the 2 properties that represents the full name.'
-            Val<String> fullName = Val.of(forename, surname, (f, s) -> f + " " + s)
+            Val<String> fullName = Val.viewOf(forename, surname, (f, s) -> f + " " + s)
         expect : 'Initially, the view has the expected value.'
             fullName.get() == "John Doe"
         when : 'We change the value of the properties.'
@@ -52,7 +52,7 @@ class Composite_Properties_Spec extends Specification
             Var<String> street = Var.of("Kingsway")
             Var<Integer> number = Var.of(123)
         and : 'Now we create a view of the 2 properties that represents the full address.'
-            Val<String> fullAddress = Val.of(street, number.viewAsString(), (s, n) -> s.isEmpty() ? null : s + " " + n)
+            Val<String> fullAddress = Val.viewOf(street, number.viewAsString(), (s, n) -> s.isEmpty() ? null : s + " " + n)
         expect : 'The view does not allow null items.'
             !fullAddress.allowsNull()
         when : 'We turn the street into an empty string to cause the view to produce a null item.'
@@ -75,7 +75,7 @@ class Composite_Properties_Spec extends Specification
             Var<Double> weight = Var.ofNull(Double)
             Var<Double> height = Var.ofNull(Double)
         and : 'A view of the 2 properties that represents the BMI.'
-            Val<Double> bmi = Val.of(weight, height, (w, h) -> w / (h * h))
+            Val<Double> bmi = Val.viewOf(weight, height, (w, h) -> w / (h * h))
         expect : 'The view does not allow null items.'
             !bmi.allowsNull()
         and : """
@@ -110,7 +110,7 @@ class Composite_Properties_Spec extends Specification
             Var<String> street = Var.of("Kingsway")
             Var<Integer> number = Var.of(123)
         and : 'Now we create a view of the 2 properties that represents the full address.'
-            Val<String> fullAddress = Val.ofNullable(street, number.viewAsString(), (s, n) -> s.isEmpty() ? null : s + " " + n)
+            Val<String> fullAddress = Val.viewOfNullable(street, number.viewAsString(), (s, n) -> s.isEmpty() ? null : s + " " + n)
         expect : 'The view allows null items.'
             fullAddress.allowsNull()
         when : 'We turn the street into an empty string to cause the view to produce a null item.'
@@ -132,7 +132,7 @@ class Composite_Properties_Spec extends Specification
             Var<Date> date1 = Var.ofNullable(Date.class, new Date())
             Var<Date> date2 = Var.ofNullable(Date.class, new Date())
         and : 'A view of the 2 properties that represents the earliest date, or null if any of the dates is null.'
-            Val<Date> earliestDate = Val.of(date1, date2, (d1, d2) -> (d1==null||d2==null) ? null : d1.before(d2) ? d1 : d2)
+            Val<Date> earliestDate = Val.viewOf(date1, date2, (d1, d2) -> (d1==null||d2==null) ? null : d1.before(d2) ? d1 : d2)
         expect : 'The view tells us that it does not allow null items.'
             !earliestDate.allowsNull()
         and : 'It contains an initial value.'
@@ -158,7 +158,7 @@ class Composite_Properties_Spec extends Specification
         """
             date1 = Var.ofNull(Date)
             date2 = Var.of(new Date())
-            earliestDate = Val.of(date1, date2, (d1, d2) -> (d1==null) ? null : d1.before(d2) ? d1 : d2)
+            earliestDate = Val.viewOf(date1, date2, (d1, d2) -> (d1==null) ? null : d1.before(d2) ? d1 : d2)
         then : 'An exception is thrown.'
             thrown(NullPointerException)
     }

--- a/src/test/groovy/sprouts/Composite_Properties_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_Properties_Spec.groovy
@@ -247,7 +247,7 @@ class Composite_Properties_Spec extends Specification
             integerVar.set(null)
         then : 'The view should be empty.'
             view.isEmpty()
-        when : 'We set a value so that the combiner returns throws an exception'
+        when : 'We set a value so that the combiner throws an exception'
             integerVar.set(9)
             doubleVar.set(null)
             then : 'The view should be empty.'


### PR DESCRIPTION
I added support for different types in composite property views.

I also fixed the old version and improved and fixed the documentation and specs as discussed in #38.
The old documentation and specs were inconsistent.