### PR TITLE
Remove 'get()' method from 'Result'

### DIFF
--- a/src/main/java/sprouts/Result.java
+++ b/src/main/java/sprouts/Result.java
@@ -215,24 +215,6 @@ public interface Result<V> extends Maybe<V>
 	}
 
 	/**
-	 * This method is intended to be used for when you want to wrap non-nullable types.
-	 * So if an item is present (not null), it returns the item, otherwise however
-	 * {@code NoSuchElementException} will be thrown.
-	 * If you simply want to get the item of this {@link Result} irrespective of
-	 * it being null or not, use {@link #orElseNull()} to avoid an exception.
-	 * However, if this result wraps a nullable type, which is not intended to be null,
-	 * please use {@link #orElseThrow()} or {@link #orElseThrowUnchecked()} to
-	 * make this intention clear to the reader of your code.
-	 * The {@link #orElseThrowUnchecked()} method is functionally identical to this method.
-	 *
-	 * @return the non-{@code null} item described by this {@code Val}
-	 * @throws NoSuchElementException if no item is present
-	 */
-	default @NonNull V get() {
-		return orElseThrowUnchecked();
-	}
-
-	/**
 	 *  Exposes a list of {@link Problem}s associated with this result item.
 	 *  A problem is a description of what went wrong in the process of obtaining
 	 *  the value wrapped by this result.

--- a/src/test/groovy/sprouts/Result_Spec.groovy
+++ b/src/test/groovy/sprouts/Result_Spec.groovy
@@ -33,9 +33,12 @@ class Result_Spec extends Specification
     def 'We can create a result from any kind of value.'()
     {
         expect :
-            Result.of(42).get() == 42
-            Result.of("foo").get() == "foo"
-            Result.of([1, 2, 3]).get() == [1, 2, 3]
+            Result.of(42).is(42)
+            Result.of("foo").is("foo")
+            Result.of([1, 2, 3]).is([1, 2, 3])
+            Result.of(42).orElseThrowUnchecked() == 42
+            Result.of("foo").orElseThrowUnchecked() == "foo"
+            Result.of([1, 2, 3]).orElseThrowUnchecked() == [1, 2, 3]
     }
 
     def 'A result can be created from multiple problems.'()
@@ -65,7 +68,8 @@ class Result_Spec extends Specification
         when : 'We map the result to another result with the value plus one.'
             def mapped = result.map { it + 1 }
         then : 'The mapped result has the value of the result plus one.'
-            mapped.get() == 43
+            mapped.is(43)
+            mapped.orElseThrowUnchecked() == 43
     }
 
     def 'Results can be turned into an Optional.'()
@@ -97,7 +101,7 @@ class Result_Spec extends Specification
         when : 'We create a result from the list.'
             def result = Result.ofList(Integer, values)
         then : 'The result has the list as its value.'
-            result.get() == values
+            result.orElseThrowUnchecked() == values
         and : 'The result has no problems.'
             result.problems().isEmpty()
     }
@@ -119,7 +123,7 @@ class Result_Spec extends Specification
         when : 'We create a result from the list.'
             def result = Result.ofList(Integer, values, problems)
         then : 'The result has the list as its value.'
-            result.get() == values
+            result.orElseThrowUnchecked() == values
         and : 'The result has the problems.'
             result.problems() == problems
     }
@@ -216,7 +220,7 @@ class Result_Spec extends Specification
         when : 'We create a result from the supplier with the `doFail` flag set to false.'
             def result = Result.ofTry(String.class, supplier)
         then : 'No exception is thrown, which means the result has the value.'
-            result.get() == "bar"
+            result.orElseThrowUnchecked() == "bar"
         and : 'The result has no problems.'
             result.problems().isEmpty()
 
@@ -274,7 +278,8 @@ class Result_Spec extends Specification
         given : 'A result.'
             def result = Result.of(42)
         expect : 'We cannot change the value of the result.'
-            result.get() == 42
+            result.is(42)
+            result.orElseThrowUnchecked() == 42
         when : 'We try to change the value of the result.'
             result.set(43)
         then : 'An exception is thrown.'


### PR DESCRIPTION
We do not want to make the same mistake as 'Optional::get'.