### PR TITLE
396 Add Support for N Scalable Composite Viewable Building

### DIFF
--- a/docs/markdown/Growing-Sprouts.md
+++ b/docs/markdown/Growing-Sprouts.md
@@ -530,6 +530,92 @@ Viewable<Double> totalPrice = Viewable.of(price, taxRate, (p, tr) -> p * (1 + tr
 // totalPrice automatically updates when either price or taxRate changes
 ```
 
+### Composite Views of Many Properties
+
+The `Viewable.of(Val, Val, BiFunction)` methods shown above merge exactly *two*
+properties. That is enough for a total price, but it does not scale: merging ten
+properties this way means nesting nine views inside each other.
+
+For that case there is a builder based factory method which takes a **seed** item and
+a chain of `join(..)` calls, where every `join` contributes one property together with
+a "wither" style combiner folding the item of that property into the composite item:
+
+```java
+record Weather(String city, double temperature, int humidity, boolean alert) {
+    Weather withCity(String city) { return new Weather(city, temperature, humidity, alert); }
+    Weather withTemperature(double t) { return new Weather(city, t, humidity, alert); }
+    Weather withHumidity(int h) { return new Weather(city, temperature, h, alert); }
+    Weather withAlert(boolean a) { return new Weather(city, temperature, humidity, a); }
+}
+
+Var<String>  city        = Var.of("Vienna");
+Var<Double>  temperature = Var.of(21.5);
+Var<Integer> humidity    = Var.of(55);
+Var<Boolean> alert       = Var.of(false);
+
+Viewable<Weather> weather = Viewable.of(new Weather("", 0, 0, false), it -> it
+        .join(city,        Weather::withCity)
+        .join(temperature, Weather::withTemperature)
+        .join(humidity,    Weather::withHumidity)
+        .join(alert,       Weather::withAlert)
+    );
+
+// weather.get() is now: Weather[city=Vienna, temperature=21.5, humidity=55, alert=false]
+```
+
+This scales to any number of properties without nesting, and because the joins are
+declared through ordinary method calls, you can also build them dynamically in a loop:
+
+```java
+record Tally(int total) {
+    Tally withTotal(int total) { return new Tally(total); }
+}
+
+List<Var<Integer>> numbers = ...;
+
+Viewable<Tally> sum = Viewable.of(new Tally(0), it -> {
+    var builder = it;
+    for ( Var<Integer> number : numbers )
+        builder = builder.join(number, (tally, n) -> tally.withTotal(tally.total() + n));
+    return builder;
+});
+```
+
+A few properties of such a composite view are worth knowing:
+
+- **The item is always recomputed as a whole.** Every recomputation starts at the seed
+  and reads the *current* item of every joined property, so the view can never mix a
+  fresh item of one source with a stale item of another. Parts of the seed which no
+  combiner ever touches simply survive in the composite item, which makes the seed the
+  natural place for constant or default state.
+- **Order matters.** The combiners are applied in the order in which the properties were
+  joined, so if two of them write to the same part, the one joined last wins. A property
+  may also be joined more than once to derive several parts of the composite item from it.
+- **The composite item is never `null`.** If a combiner returns `null` or throws while the
+  view is being *created*, the creation fails with a `NullPointerException`. If it happens
+  later, while a change is being *propagated*, the whole recomputation is discarded, a
+  warning is logged, and the view keeps its last item &mdash; so it is never observed in a
+  half updated state.
+- **It is read-only.** The way to change a composite view is to change one of the
+  properties it was folded from.
+
+The item type of the view is taken from the concrete class of the seed. When your item
+type is polymorphic, pin it explicitly with the `Class` based overload:
+
+```java
+Viewable<Shape> shape = Viewable.of(Shape.class, new Rect(1, 1), it -> it
+        .join(kind, (s, k) -> "circle".equals(k) ? new Circle(1) : new Rect(1, 1))
+    );
+```
+
+> [!TIP]
+> A composite view follows the same referencing policy as every other view: the
+> properties it observes reference it only *weakly*, so keep a strong reference to it
+> for as long as you need it. In the other direction, a joined *view or lens* is
+> referenced strongly &mdash; which is what lets you create intermediate properties
+> inline inside the configurator &mdash; while a joined *plain property* is referenced
+> weakly, so that observing your state never keeps it alive.
+
 ## Conclusion
 
 Sprouts provides a robust foundation for building modern Java applications with:
@@ -537,6 +623,7 @@ Sprouts provides a robust foundation for building modern Java applications with:
 - **Immutable data models** that are safe, fast and predictable
 - **Property lenses** for fine-grained state management
 - **Property views** for viewing and reacting to state changes
+- **Composite views** for merging any number of properties into a single item
 - **Automatic memory management** through weak-referenced views
 - **Type-safe** operations throughout
 

--- a/src/main/java/sprouts/Viewable.java
+++ b/src/main/java/sprouts/Viewable.java
@@ -7,6 +7,7 @@ import sprouts.impl.Sprouts;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  *  A read-only live view on a delegated item derived from a {@link Var} or {@link Val}, which
@@ -227,6 +228,93 @@ public interface Viewable<T> extends Val<T>, Observable {
     }
 
     /**
+     * Creates an observable read-only {@link Viewable} property which is a live view of an arbitrary
+     * number of other properties, merged into a single item of type {@code C}.
+     * <p>
+     * Contrary to the {@link #of(Val, Val, BiFunction)} family of factory methods, which is limited to
+     * exactly two properties, this method scales to any number of properties without nesting.
+     * The supplied {@code configurator} receives a {@link CompositeBuilder} on which every
+     * {@link CompositeBuilder#join(Val, BiFunction)} call contributes one property together with a
+     * "wither" style combiner folding the item of that property into the composite item:
+     * <pre>{@code
+     *   Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+     *           .join(cityProperty,        Weather::withCity)
+     *           .join(temperatureProperty, Weather::withTemperature)
+     *           .join(humidityProperty,    Weather::withHumidity)
+     *       );
+     * }</pre>
+     * The item of the resulting property is always recomputed <b>as a whole</b>: the fold starts at the
+     * supplied {@code seed} and applies every combiner in the order in which the properties were joined,
+     * reading the <b>current</b> item of every joined property. So a part of the seed which no combiner
+     * ever touches simply survives in the composite item, and if two combiners write to the same part,
+     * then the one which was joined last wins.
+     * <p>
+     * Note: The composite view does <b>not</b> allow storing {@code null} references!
+     * If a combiner returns {@code null} or throws an exception when the view is created, then a
+     * {@link NullPointerException} is thrown. If this happens later on, while a change is being
+     * propagated, then the whole recomputation is discarded, a warning is logged, and the view simply
+     * retains its last item, so it is never observed in a half updated state.
+     * <p>
+     * The {@link #type()} of the returned property is the concrete class of the supplied {@code seed}.
+     * If the item type is polymorphic, and your combiners may produce a sibling subtype, then use the
+     * {@link #of(Class, Object, Function)} method instead to pin the type explicitly.
+     * <p>
+     * <b>Warning:</b> Just like every other view, the returned {@link Viewable} is only weakly referenced
+     * by the properties it observes. If you do not keep a strong reference to it, then it will eventually
+     * be garbage collected alongside all of its change listeners. Note that a composite view does keep a
+     * strong reference to every joined property which is itself a view or a lens, so you may create those
+     * inline inside the {@code configurator}.
+     *
+     * @param seed         The initial item at which the fold of the composite item starts.
+     * @param configurator A function declaring the joined properties on the supplied {@link CompositeBuilder}
+     *                     and returning the resulting builder.
+     * @param <C>          The type of the item held by the returned {@link Viewable}.
+     * @return A new {@link Viewable} instance which is a live view of all the joined properties.
+     * @throws NullPointerException If any of the supplied arguments is {@code null}, if the
+     *                              {@code configurator} returns {@code null}, or if the initial fold
+     *                              fails to produce an item.
+     */
+    static <C> Viewable<C> of( C seed, Function<CompositeBuilder<C>, CompositeBuilder<C>> configurator ) {
+        Objects.requireNonNull(seed);
+        Objects.requireNonNull(configurator);
+        @SuppressWarnings("unchecked")
+        Class<C> type = (Class<C>) seed.getClass();
+        return Sprouts.factory().viewOf( type, seed, configurator );
+    }
+
+    /**
+     * Creates an observable read-only {@link Viewable} property which is a live view of an arbitrary
+     * number of other properties, merged into a single item of the supplied type {@code C}.
+     * <p>
+     * This method behaves exactly like {@link #of(Object, Function)}, except that the {@link #type()} of
+     * the returned property is not inferred from the concrete class of the {@code seed}, but pinned to
+     * the supplied {@code type}. Use this overload whenever {@code C} is polymorphic, because a composite
+     * view whose type was inferred from the seed cannot hold a sibling subtype of it:
+     * <pre>{@code
+     *   Viewable<Shape> shape = Viewable.of(Shape.class, new Rect(1, 1), it -> it
+     *           .join(kindProperty, (s, kind) -> "circle".equals(kind) ? new Circle(1) : new Rect(1, 1))
+     *           .join(sizeProperty, (s, size) -> s instanceof Circle ? new Circle(size) : new Rect(size, size))
+     *       );
+     * }</pre>
+     *
+     * @param type         The type of the item held by the returned {@link Viewable}.
+     * @param seed         The initial item at which the fold of the composite item starts.
+     * @param configurator A function declaring the joined properties on the supplied {@link CompositeBuilder}
+     *                     and returning the resulting builder.
+     * @param <C>          The type of the item held by the returned {@link Viewable}.
+     * @return A new {@link Viewable} instance which is a live view of all the joined properties.
+     * @throws NullPointerException If any of the supplied arguments is {@code null}, if the
+     *                              {@code configurator} returns {@code null}, or if the initial fold
+     *                              fails to produce an item.
+     */
+    static <C> Viewable<C> of( Class<C> type, C seed, Function<CompositeBuilder<C>, CompositeBuilder<C>> configurator ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(seed);
+        Objects.requireNonNull(configurator);
+        return Sprouts.factory().viewOf( type, seed, configurator );
+    }
+
+    /**
      *  Use this to register an observer lambda for a particular {@link Channel},
      *  which will be called whenever the item viewed
      *  by this {@link Viewable} changes through the {@code Var::set(Channel, T)} method.
@@ -250,5 +338,46 @@ public interface Viewable<T> extends Val<T>, Observable {
      * @return The {@link Viewable} instance itself.
      */
     Viewable<T> onChange( Channel channel, Action<ValDelegate<T>> action );
+
+    /**
+     *  An immutable builder used to declare the properties a composite {@link Viewable} is merged from.
+     *  An instance of this is supplied to the {@code configurator} function of the
+     *  {@link Viewable#of(Object, Function)} and {@link Viewable#of(Class, Object, Function)}
+     *  factory methods, where every {@link #join(Val, BiFunction)} call contributes one property
+     *  together with the combiner folding its item into the composite item.
+     *  <p>
+     *  Note that this is a persistent value: {@link #join(Val, BiFunction)} does not modify the builder
+     *  it is called on, but returns a new one. No change listeners are registered before the
+     *  {@code configurator} has returned, which means an instance of this which escapes from the
+     *  {@code configurator} is completely inert.
+     *
+     * @param <C> The type of the item held by the composite {@link Viewable} being built.
+     */
+    interface CompositeBuilder<C>
+    {
+        /**
+         *  Declares that the item of the supplied {@code property} should be folded into the item of
+         *  the composite {@link Viewable} using the supplied {@code combiner}, which receives the
+         *  composite item as folded so far, together with the current item of the property, and
+         *  returns the updated composite item.
+         *  <p>
+         *  The combiners of a composite view are applied in the order in which their properties were
+         *  joined, so if two of them write to the same part of the composite item, then the one which
+         *  was joined last wins. A property may also be joined more than once, in which case every join
+         *  is an independent contribution to the fold.
+         *  <p>
+         *  Note that the supplied {@code property} may be nullable, in which case the {@code combiner}
+         *  must be prepared to receive a {@code null} item. The composite item itself may never be
+         *  {@code null}, so a combiner returning {@code null} is treated as a failure.
+         *
+         * @param property The property whose item should be folded into the composite item.
+         * @param combiner A function receiving the composite item folded so far together with the
+         *                 current item of the supplied property, and returning the updated composite item.
+         * @param <V> The type of the item held by the supplied property.
+         * @return A new {@link CompositeBuilder} with the supplied property joined to it.
+         * @throws NullPointerException If any of the supplied arguments is {@code null}.
+         */
+        <V extends @Nullable Object> CompositeBuilder<C> join( Val<V> property, BiFunction<C, V, C> combiner );
+    }
 
 }

--- a/src/main/java/sprouts/Viewable.java
+++ b/src/main/java/sprouts/Viewable.java
@@ -261,9 +261,9 @@ public interface Viewable<T> extends Val<T>, Observable {
      * <p>
      * <b>Warning:</b> Just like every other view, the returned {@link Viewable} is only weakly referenced
      * by the properties it observes. If you do not keep a strong reference to it, then it will eventually
-     * be garbage collected alongside all of its change listeners. Note that a composite view does keep a
-     * strong reference to every joined property which is itself a view or a lens, so you may create those
-     * inline inside the {@code configurator}.
+     * be garbage collected alongside all of its change listeners. Note that the opposite direction is a
+     * strong reference: a composite view keeps every property it joined alive, so you may create views
+     * and lenses inline inside the {@code configurator} without having to store them yourself.
      *
      * @param seed         The initial item at which the fold of the composite item starts.
      * @param configurator A function declaring the joined properties on the supplied {@link CompositeBuilder}

--- a/src/main/java/sprouts/Viewable.java
+++ b/src/main/java/sprouts/Viewable.java
@@ -278,6 +278,8 @@ public interface Viewable<T> extends Val<T>, Observable {
      * @throws NullPointerException If any of the supplied arguments is {@code null}, if the
      *                              {@code configurator} returns {@code null}, or if the initial fold
      *                              fails to produce an item.
+     * @throws IllegalArgumentException If the {@code configurator} returns a builder which did not
+     *                                  originate from the one it was supplied with.
      */
     static <C> Viewable<C> of( C seed, Function<CompositeBuilder<C>, CompositeBuilder<C>> configurator ) {
         Objects.requireNonNull(seed);
@@ -311,6 +313,9 @@ public interface Viewable<T> extends Val<T>, Observable {
      * @throws NullPointerException If any of the supplied arguments is {@code null}, if the
      *                              {@code configurator} returns {@code null}, or if the initial fold
      *                              fails to produce an item.
+     * @throws IllegalArgumentException If the supplied {@code seed} is not an instance of the supplied
+     *                                  {@code type}, or if the {@code configurator} returns a builder
+     *                                  which did not originate from the one it was supplied with.
      */
     static <C> Viewable<C> of( Class<C> type, C seed, Function<CompositeBuilder<C>, CompositeBuilder<C>> configurator ) {
         Objects.requireNonNull(type);
@@ -369,7 +374,8 @@ public interface Viewable<T> extends Val<T>, Observable {
          *  The combiners of a composite view are applied in the order in which their properties were
          *  joined, so if two of them write to the same part of the composite item, then the one which
          *  was joined last wins. A property may also be joined more than once, in which case every join
-         *  is an independent contribution to the fold.
+         *  is an independent contribution to the fold, while the property itself is still observed
+         *  only once.
          *  <p>
          *  Note that the supplied {@code property} may be nullable, in which case the {@code combiner}
          *  must be prepared to receive a {@code null} item. The composite item itself may never be

--- a/src/main/java/sprouts/Viewable.java
+++ b/src/main/java/sprouts/Viewable.java
@@ -261,9 +261,14 @@ public interface Viewable<T> extends Val<T>, Observable {
      * <p>
      * <b>Warning:</b> Just like every other view, the returned {@link Viewable} is only weakly referenced
      * by the properties it observes. If you do not keep a strong reference to it, then it will eventually
-     * be garbage collected alongside all of its change listeners. Note that the opposite direction is a
-     * strong reference: a composite view keeps every property it joined alive, so you may create views
-     * and lenses inline inside the {@code configurator} without having to store them yourself.
+     * be garbage collected alongside all of its change listeners.
+     * <p>
+     * A composite view also references the properties it joined the same way any other view references
+     * the property it is derived from: a joined <i>view</i> or <i>lens</i> is referenced strongly, so
+     * you may create intermediate properties inline inside the {@code configurator} without having to
+     * store them yourself, whereas a joined <i>plain property</i> is referenced weakly, so that a view
+     * never keeps your actual state alive. If such a plain property is garbage collected, then the
+     * composite view keeps folding in its last known item instead of breaking.
      *
      * @param seed         The initial item at which the fold of the composite item starts.
      * @param configurator A function declaring the joined properties on the supplied {@link CompositeBuilder}

--- a/src/main/java/sprouts/impl/CompositeBuilderImpl.java
+++ b/src/main/java/sprouts/impl/CompositeBuilderImpl.java
@@ -1,0 +1,55 @@
+package sprouts.impl;
+
+import org.jspecify.annotations.Nullable;
+import sprouts.Val;
+import sprouts.Viewable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+/**
+ *  The implementation of the {@link Viewable.CompositeBuilder} interface, which collects the
+ *  properties a composite view is folded from, together with their combiners.
+ *  <p>
+ *  This is a persistent value: {@link #join(Val, BiFunction)} does not modify the builder it is
+ *  called on, but returns a new one carrying one additional {@link CompositeCore.Join}.
+ *  Nothing is registered on the joined properties here, which is what makes an instance of this
+ *  inert once it escapes the configurator function it was handed to.
+ *
+ * @param <C> The item type of the composite view being built.
+ */
+final class CompositeBuilderImpl<C> implements Viewable.CompositeBuilder<C> {
+
+    private static final CompositeBuilderImpl<?> EMPTY = new CompositeBuilderImpl<>(Collections.emptyList());
+
+    @SuppressWarnings("unchecked")
+    static <C> CompositeBuilderImpl<C> empty() {
+        return (CompositeBuilderImpl<C>) EMPTY;
+    }
+
+    private final List<CompositeCore.Join<C, ?>> _joins;
+
+    private CompositeBuilderImpl( List<CompositeCore.Join<C, ?>> joins ) {
+        _joins = joins;
+    }
+
+    @Override
+    public <V extends @Nullable Object> Viewable.CompositeBuilder<C> join(
+        Val<V>              property,
+        BiFunction<C, V, C> combiner
+    ) {
+        Objects.requireNonNull(property, "The property to join must not be null.");
+        Objects.requireNonNull(combiner, "The combiner of a joined property must not be null.");
+        List<CompositeCore.Join<C, ?>> joins = new ArrayList<>(_joins.size() + 1);
+        joins.addAll(_joins);
+        joins.add(new CompositeCore.Join<>(property, combiner));
+        return new CompositeBuilderImpl<>(Collections.unmodifiableList(joins));
+    }
+
+    List<CompositeCore.Join<C, ?>> joins() {
+        return _joins;
+    }
+}

--- a/src/main/java/sprouts/impl/CompositeBuilderImpl.java
+++ b/src/main/java/sprouts/impl/CompositeBuilderImpl.java
@@ -1,12 +1,10 @@
 package sprouts.impl;
 
 import org.jspecify.annotations.Nullable;
+import sprouts.Tuple;
 import sprouts.Val;
 import sprouts.Viewable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
@@ -16,6 +14,9 @@ import java.util.function.BiFunction;
  *  <p>
  *  This is a persistent value: {@link #join(Val, BiFunction)} does not modify the builder it is
  *  called on, but returns a new one carrying one additional {@link CompositeCore.Join}.
+ *  The joins are collected in a {@link Tuple}, whose structural sharing is what keeps a chain of
+ *  {@code join(..)} calls from copying everything which was already declared, over and over again.
+ *  <p>
  *  Nothing is registered on the joined properties here, which is what makes an instance of this
  *  inert once it escapes the configurator function it was handed to.
  *
@@ -23,16 +24,27 @@ import java.util.function.BiFunction;
  */
 final class CompositeBuilderImpl<C> implements Viewable.CompositeBuilder<C> {
 
-    private static final CompositeBuilderImpl<?> EMPTY = new CompositeBuilderImpl<>(Collections.emptyList());
+    private static final CompositeBuilderImpl<?> EMPTY = new CompositeBuilderImpl<>(_noJoins());
 
     @SuppressWarnings("unchecked")
     static <C> CompositeBuilderImpl<C> empty() {
         return (CompositeBuilderImpl<C>) EMPTY;
     }
 
-    private final List<CompositeCore.Join<C, ?>> _joins;
+    /**
+     *  The item type of the tuple of joins is generic, which a {@link Class} can never express,
+     *  so the raw {@link CompositeCore.Join} class is the most precise type we can hand to the
+     *  tuple. It only ever uses it to type check the items it is given, and every join is an
+     *  instance of that raw type, no matter its type arguments.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <C> Tuple<CompositeCore.Join<C, ?>> _noJoins() {
+        return (Tuple) Tuple.of(CompositeCore.Join.class);
+    }
 
-    private CompositeBuilderImpl( List<CompositeCore.Join<C, ?>> joins ) {
+    private final Tuple<CompositeCore.Join<C, ?>> _joins;
+
+    private CompositeBuilderImpl( Tuple<CompositeCore.Join<C, ?>> joins ) {
         _joins = joins;
     }
 
@@ -43,13 +55,10 @@ final class CompositeBuilderImpl<C> implements Viewable.CompositeBuilder<C> {
     ) {
         Objects.requireNonNull(property, "The property to join must not be null.");
         Objects.requireNonNull(combiner, "The combiner of a joined property must not be null.");
-        List<CompositeCore.Join<C, ?>> joins = new ArrayList<>(_joins.size() + 1);
-        joins.addAll(_joins);
-        joins.add(new CompositeCore.Join<>(property, combiner));
-        return new CompositeBuilderImpl<>(Collections.unmodifiableList(joins));
+        return new CompositeBuilderImpl<>(_joins.add(new CompositeCore.Join<>(property, combiner)));
     }
 
-    List<CompositeCore.Join<C, ?>> joins() {
+    Tuple<CompositeCore.Join<C, ?>> joins() {
         return _joins;
     }
 }

--- a/src/main/java/sprouts/impl/CompositeCore.java
+++ b/src/main/java/sprouts/impl/CompositeCore.java
@@ -142,16 +142,29 @@ final class CompositeCore<C> implements LensCore<C> {
      *  Immutable properties are left out, because their item can never change, so observing
      *  them would only produce listeners which are never called. They are still folded into
      *  the composite item, they are just not listened to.
+     *  <p>
+     *  A property which was joined more than once is reported only once, because the fold reads
+     *  the current item of every join anyway, so a second listener on the same property would
+     *  only recompute the very same item again. Worse, a forced change event, which is
+     *  propagated even when the item did not change, would then be multiplied by the number
+     *  of times the property was joined.
      */
     @Override
     public List<? extends Val<?>> sources() {
         List<Val<?>> observed = new ArrayList<>(_joins.size());
         for ( Join<C, ?> join : _joins ) {
             Val<?> property = join.property();
-            if ( property.isMutable() )
+            if ( property.isMutable() && !_containsIdentical(observed, property) )
                 observed.add(property);
         }
         return observed;
+    }
+
+    private static boolean _containsIdentical( List<Val<?>> properties, Val<?> property ) {
+        for ( int i = 0; i < properties.size(); i++ )
+            if ( properties.get(i) == property )
+                return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/sprouts/impl/CompositeCore.java
+++ b/src/main/java/sprouts/impl/CompositeCore.java
@@ -37,43 +37,37 @@ final class CompositeCore<C> implements LensCore<C> {
     /**
      *  A single contribution to the fold of a composite view, which is one joined
      *  property together with the combiner folding its item into the composite item.
+     *  <p>
+     *  Note that the joined property is held through a {@link ParentRef}, which is how
+     *  a composite view follows the same referencing policy as any other view: a joined
+     *  view or lens is referenced strongly, so that intermediate properties created inline
+     *  inside a configurator stay alive, whereas a plain property is referenced weakly, so
+     *  that observing your state never keeps it alive.
      */
     static final class Join<C, V extends @Nullable Object> {
-        private final Val<V>               _property;
+        private final ParentRef<Val<V>>    _property;
         private final BiFunction<C, V, C>  _combiner;
 
         Join( Val<V> property, BiFunction<C, V, C> combiner ) {
-            _property = property; // Vetted by CompositeBuilderImpl, the only place creating these.
+            _property = ParentRef.of(property); // Vetted by CompositeBuilderImpl, the only place creating these.
             _combiner = combiner;
         }
 
-        Val<V> property() { return _property; }
+        Val<V> property() { return _property.get(); }
 
         C applyTo( C item ) {
-            return _combiner.apply(item, _property.orElseNull());
+            return _combiner.apply(item, _property.get().orElseNull());
         }
     }
 
-    private final Class<C>            _type;
-    private final C                   _seed;
-    private final List<Join<C, ?>>    _joins;
-    private final List<Val<?>>        _observedSources;
+    private final Class<C>         _type;
+    private final C                _seed;
+    private final List<Join<C, ?>> _joins;
 
     CompositeCore( Class<C> type, C seed, List<Join<C, ?>> joins ) {
         _type  = Objects.requireNonNull(type);
         _seed  = Objects.requireNonNull(seed);
         _joins = Collections.unmodifiableList(new ArrayList<>(joins));
-        /*
-            An immutable property can never change its item, so observing it would only
-            produce a change listener which is never called. We still fold its item into
-            the composite item, we just do not listen to it.
-        */
-        List<Val<?>> observed = new ArrayList<>(_joins.size());
-        for ( Join<C, ?> join : _joins ) {
-            if ( join.property().isMutable() )
-                observed.add(join.property());
-        }
-        _observedSources = Collections.unmodifiableList(observed);
     }
 
     /**
@@ -137,9 +131,27 @@ final class CompositeCore<C> implements LensCore<C> {
         );
     }
 
+    /**
+     *  {@inheritDoc}
+     *  <p>
+     *  The returned list is computed on demand and deliberately <b>not</b> retained in a field:
+     *  holding it would be a strong reference to every joined property, which would defeat the
+     *  weak {@link ParentRef}s the joins are based on. The {@link PropertyLens} only consumes
+     *  this once, when it registers its weak listeners.
+     *  <p>
+     *  Immutable properties are left out, because their item can never change, so observing
+     *  them would only produce listeners which are never called. They are still folded into
+     *  the composite item, they are just not listened to.
+     */
     @Override
     public List<? extends Val<?>> sources() {
-        return _observedSources;
+        List<Val<?>> observed = new ArrayList<>(_joins.size());
+        for ( Join<C, ?> join : _joins ) {
+            Val<?> property = join.property();
+            if ( property.isMutable() )
+                observed.add(property);
+        }
+        return observed;
     }
 
     @Override

--- a/src/main/java/sprouts/impl/CompositeCore.java
+++ b/src/main/java/sprouts/impl/CompositeCore.java
@@ -1,0 +1,172 @@
+package sprouts.impl;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import sprouts.Channel;
+import sprouts.Val;
+import sprouts.Viewable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+/**
+ *  A read-only {@link LensCore} which folds the items of an arbitrary number of joined
+ *  properties into a single composite item, starting at a seed item.
+ *  It is the engine behind {@link Viewable#of(Object, java.util.function.Function)} and
+ *  {@link Viewable#of(Class, Object, java.util.function.Function)}.
+ *  <p>
+ *  Contrary to the lens cores, this one derives its item from <b>all</b> of its sources at once,
+ *  which is what makes a composite view free of intermediate items: every recomputation reads
+ *  the current item of every joined property instead of remembering what it was told, so it
+ *  cannot mix a fresh item of one source with a stale item of another.
+ *  <p>
+ *  The fold is applied atomically: should any of the combiners fail, produce {@code null} or
+ *  produce an item which does not fit the item type of the composite, then the <b>whole</b>
+ *  recomputation is discarded in favour of the last known item, so that a composite view is
+ *  never observed in a half updated state.
+ *
+ * @param <C> The item type of the composite property.
+ */
+final class CompositeCore<C> implements LensCore<C> {
+
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(CompositeCore.class);
+
+    /**
+     *  A single contribution to the fold of a composite view, which is one joined
+     *  property together with the combiner folding its item into the composite item.
+     */
+    static final class Join<C, V extends @Nullable Object> {
+        private final Val<V>               _property;
+        private final BiFunction<C, V, C>  _combiner;
+
+        Join( Val<V> property, BiFunction<C, V, C> combiner ) {
+            _property = property; // Vetted by CompositeBuilderImpl, the only place creating these.
+            _combiner = combiner;
+        }
+
+        Val<V> property() { return _property; }
+
+        C applyTo( C item ) {
+            return _combiner.apply(item, _property.orElseNull());
+        }
+    }
+
+    private final Class<C>            _type;
+    private final C                   _seed;
+    private final List<Join<C, ?>>    _joins;
+    private final List<Val<?>>        _observedSources;
+
+    CompositeCore( Class<C> type, C seed, List<Join<C, ?>> joins ) {
+        _type  = Objects.requireNonNull(type);
+        _seed  = Objects.requireNonNull(seed);
+        _joins = Collections.unmodifiableList(new ArrayList<>(joins));
+        /*
+            An immutable property can never change its item, so observing it would only
+            produce a change listener which is never called. We still fold its item into
+            the composite item, we just do not listen to it.
+        */
+        List<Val<?>> observed = new ArrayList<>(_joins.size());
+        for ( Join<C, ?> join : _joins ) {
+            if ( join.property().isMutable() )
+                observed.add(join.property());
+        }
+        _observedSources = Collections.unmodifiableList(observed);
+    }
+
+    /**
+     *  Folds the items of all joined properties into a single composite item,
+     *  starting at the seed and applying every combiner in join order.
+     *
+     * @param lastKnownItem The item to fall back to if the fold fails, which may be
+     *                      {@code null} while the composite view is still being derived.
+     * @param logDegradation Whether falling back to {@code lastKnownItem} should be logged.
+     * @return The folded item, or {@code lastKnownItem} if the fold failed.
+     */
+    @Override
+    public @Nullable C fetchFromSources( @Nullable C lastKnownItem, boolean logDegradation ) {
+        C folded = _seed;
+        for ( int i = 0; i < _joins.size(); i++ ) {
+            Join<C, ?> join = _joins.get(i);
+            try {
+                folded = join.applyTo(folded);
+            } catch ( Exception e ) {
+                Util.sneakyThrowExceptionIfFatal(e);
+                if ( logDegradation )
+                    _logError(
+                        "The combiner joined to property {} (at index {}) of a composite view " +
+                        "threw an exception. The whole recomputation is discarded and the " +
+                        "composite view retains its last item '{}'.",
+                        _describe(join.property()), i, lastKnownItem, e
+                    );
+                return lastKnownItem;
+            }
+            if ( folded == null ) {
+                if ( logDegradation )
+                    _logError(
+                        "The combiner joined to property {} (at index {}) of a composite view " +
+                        "returned null, but a composite view does not allow null items. " +
+                        "The whole recomputation is discarded and the composite view retains " +
+                        "its last item '{}'.",
+                        _describe(join.property()), i, lastKnownItem
+                    );
+                return lastKnownItem;
+            }
+        }
+        if ( !_type.isInstance(folded) ) {
+            if ( logDegradation )
+                _logError(
+                    "The combiners of a composite view produced an item of type '{}', which does " +
+                    "not fit the item type '{}' of the view. The whole recomputation is discarded " +
+                    "and the composite view retains its last item '{}'. Use the " +
+                    "'Viewable.of(Class, Object, Function)' factory method to declare a common " +
+                    "supertype explicitly.",
+                    folded.getClass(), _type, lastKnownItem
+                );
+            return lastKnownItem;
+        }
+        return folded;
+    }
+
+    @Override
+    public void writeToSources( Channel channel, @Nullable C newItem ) {
+        throw new UnsupportedOperationException(
+            "A composite view is read-only! Change one of the properties it is composed of instead."
+        );
+    }
+
+    @Override
+    public List<? extends Val<?>> sources() {
+        return _observedSources;
+    }
+
+    @Override
+    public boolean isView() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSuppressSourceCallback() {
+        return false;
+    }
+
+    @Override
+    public String coreName() {
+        return "View";
+    }
+
+    @Override
+    public LensCore<C> newInstance() {
+        return this; // no mutable state — safe to share
+    }
+
+    private static String _describe( Val<?> property ) {
+        return property.id().isEmpty() ? "of type '" + property.type() + "'" : "'" + property.id() + "'";
+    }
+
+    private static void _logError( String message, @Nullable Object... args ) {
+        Util._logError(log, message, args);
+    }
+}

--- a/src/main/java/sprouts/impl/CompositeCore.java
+++ b/src/main/java/sprouts/impl/CompositeCore.java
@@ -6,8 +6,9 @@ import sprouts.Channel;
 import sprouts.Val;
 import sprouts.Viewable;
 
+import sprouts.Tuple;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -60,14 +61,14 @@ final class CompositeCore<C> implements LensCore<C> {
         }
     }
 
-    private final Class<C>         _type;
-    private final C                _seed;
-    private final List<Join<C, ?>> _joins;
+    private final Class<C>          _type;
+    private final C                 _seed;
+    private final Tuple<Join<C, ?>> _joins;
 
-    CompositeCore( Class<C> type, C seed, List<Join<C, ?>> joins ) {
+    CompositeCore( Class<C> type, C seed, Tuple<Join<C, ?>> joins ) {
         _type  = Objects.requireNonNull(type);
         _seed  = Objects.requireNonNull(seed);
-        _joins = Collections.unmodifiableList(new ArrayList<>(joins));
+        _joins = Objects.requireNonNull(joins); // A tuple is immutable, so there is nothing to defend against here.
     }
 
     /**

--- a/src/main/java/sprouts/impl/DualLensCore.java
+++ b/src/main/java/sprouts/impl/DualLensCore.java
@@ -56,7 +56,7 @@ final class DualLensCore<A extends @Nullable Object, B extends @Nullable Object,
     }
 
     @Override
-    public @Nullable T fetchFromSources(@Nullable T lastKnownItem) {
+    public @Nullable T fetchFromSources(@Nullable T lastKnownItem, boolean logDegradation) {
         T fetchedValue = lastKnownItem;
         try {
             fetchedValue = _getter.apply(
@@ -65,13 +65,14 @@ final class DualLensCore<A extends @Nullable Object, B extends @Nullable Object,
             );
         } catch ( Exception e ) {
             Util.sneakyThrowExceptionIfFatal(e);
-            Util._logError(log,
-                    "Failed to fetch item for dual property lens from source " +
-                    "properties '{}' and '{}' using the current getter function.",
-                    _firstParent.id().isEmpty()  ? "?" : "'" + _firstParent.id()  + "'",
-                    _secondParent.id().isEmpty() ? "?" : "'" + _secondParent.id() + "'",
-                    e
-            );
+            if ( logDegradation )
+                Util._logError(log,
+                        "Failed to fetch item for dual property lens from source " +
+                        "properties '{}' and '{}' using the current getter function.",
+                        _firstParent.id().isEmpty()  ? "?" : "'" + _firstParent.id()  + "'",
+                        _secondParent.id().isEmpty() ? "?" : "'" + _secondParent.id() + "'",
+                        e
+                );
         }
         return fetchedValue;
     }

--- a/src/main/java/sprouts/impl/LensCore.java
+++ b/src/main/java/sprouts/impl/LensCore.java
@@ -7,46 +7,68 @@ import sprouts.Val;
 import java.util.List;
 
 /**
- * Abstracts the source-interaction behavior of a property lens.
- * A {@link PropertyLens} delegates all source-specific logic to a {@code LensCore}:
- * fetching the current item from parent source(s), writing a new item back,
- * and registering change listeners on those sources.
+ * Abstracts the source-interaction behavior of a property which derives its item from
+ * one or more other properties. A {@link PropertyLens} delegates all source-specific
+ * logic to a {@code LensCore}: fetching the current item from the source(s), writing a
+ * new item back, and telling the property which sources to observe.
  * <p>
  * Implementations include:
  * <ul>
  *   <li>{@link SingleLensCore} &mdash; a single parent property with a {@link sprouts.Lens}</li>
  *   <li>{@link DualLensCore} &mdash; two parent properties with a getter/setter pair</li>
  *   <li>{@link ParamLensCore} &mdash; a parent property combined with an external parameterized getter/setter pair</li>
+ *   <li>{@link CompositeCore} &mdash; a read-only fold over an arbitrary number of joined properties</li>
  * </ul>
  *
- * @param <T> The item type of the lens property.
+ * @param <T> The item type of the derived property.
  */
 interface LensCore<T extends @Nullable Object> {
 
     /**
      * Fetches the current item from the parent source(s).
-     * On error, the implementation should log and return {@code lastKnownItem} as a fallback.
+     * On error, the implementation should return {@code lastKnownItem} as a fallback,
+     * so that a derived property never exposes a half computed or illegal item.
      *
      * @param lastKnownItem The last known item, used as fallback if fetching fails.
+     * @param logDegradation Whether falling back to {@code lastKnownItem} should be logged.
+     *                       This is {@code true} on the event-propagation path, where the
+     *                       anomaly first occurs, and {@code false} on the ordinary read path,
+     *                       which would otherwise report the very same problem over and over
+     *                       again for as long as the sources stay in their broken state.
      * @return The fetched item, or {@code lastKnownItem} on error.
      */
-    @Nullable T fetchFromSources(@Nullable T lastKnownItem);
+    @Nullable T fetchFromSources(@Nullable T lastKnownItem, boolean logDegradation);
 
     /**
      * Writes a new item back to the parent source(s).
      *
      * @param channel The channel to use for the write.
      * @param newItem The new item to write.
+     * @throws UnsupportedOperationException If this core is read-only, see {@link #isView()}.
      */
     void writeToSources(Channel channel, @Nullable T newItem);
 
     /**
      * Returns the parent source properties that this core observes.
-     * The {@link PropertyLens} subscribes to each of these with weak listeners.
+     * The {@link PropertyLens} subscribes to each of these with weak listeners,
+     * which is why immutable sources should be left out: their item can never change,
+     * so observing them would only produce listeners that are never called.
      *
-     * @return An {@link Iterable} over all parent source properties.
+     * @return An {@link Iterable} over all observed parent source properties.
      */
     Iterable<? extends Val<?>> sources();
+
+    /**
+     * Whether the property backed by this core is a read-only view instead of a lens.
+     * This determines what {@link sprouts.Val#isView()} and {@link sprouts.Val#isLens()}
+     * report for the derived property. A core which returns {@code true} here is not
+     * required to support {@link #writeToSources(Channel, Object)}.
+     *
+     * @return {@code true} if the derived property should present itself as a view.
+     */
+    default boolean isView() {
+        return false;
+    }
 
     /**
      * Whether a source-change callback should be suppressed.

--- a/src/main/java/sprouts/impl/ParamLensCore.java
+++ b/src/main/java/sprouts/impl/ParamLensCore.java
@@ -46,7 +46,7 @@ final class ParamLensCore<P extends @Nullable Object, A extends @Nullable Object
     }
 
     @Override
-    public @Nullable T fetchFromSources(@Nullable T lastKnownItem) {
+    public @Nullable T fetchFromSources(@Nullable T lastKnownItem, boolean logDegradation) {
         T fetchedValue = lastKnownItem;
         try {
             fetchedValue = _getter.apply(
@@ -55,16 +55,17 @@ final class ParamLensCore<P extends @Nullable Object, A extends @Nullable Object
             );
         } catch ( Exception e ) {
             Util.sneakyThrowExceptionIfFatal(e);
-            Util._logError(log,
-                    "Failed to fetch item for parameterized property lens from source " +
-                    "property {} (with item type '{}') and parameter {} (with item type '{}') " +
-                    "using the current getter function.",
-                    _source.id().isEmpty()    ? "?" : "'" + _source.id()    + "'",
-                    _source.type(),
-                    _parameter.id().isEmpty() ? "?" : "'" + _parameter.id() + "'",
-                    _parameter.type(),
-                    e
-            );
+            if ( logDegradation )
+                Util._logError(log,
+                        "Failed to fetch item for parameterized property lens from source " +
+                        "property {} (with item type '{}') and parameter {} (with item type '{}') " +
+                        "using the current getter function.",
+                        _source.id().isEmpty()    ? "?" : "'" + _source.id()    + "'",
+                        _source.type(),
+                        _parameter.id().isEmpty() ? "?" : "'" + _parameter.id() + "'",
+                        _parameter.type(),
+                        e
+                );
         }
         return fetchedValue;
     }

--- a/src/main/java/sprouts/impl/PropertyLens.java
+++ b/src/main/java/sprouts/impl/PropertyLens.java
@@ -447,7 +447,7 @@ final class PropertyLens<T extends @Nullable Object> implements Var<T>, Viewable
      *  if this lens does not allow null, but the sources currently yield {@code null}
      *  (e.g. because the focused field became null through an update of the parent),
      *  then we keep the last known item instead of exposing an illegal null item.
-     *  This mirrors how {@link SingleLensCore#fetchFromSources(Object)} already keeps
+     *  This mirrors how {@link SingleLensCore#fetchFromSources(Object, boolean)} already keeps
      *  the last item when the lens getter throws, and it guarantees that a
      *  non-nullable lens never violates its own {@code allowsNull() == false} contract.
      *  <p>

--- a/src/main/java/sprouts/impl/PropertyLens.java
+++ b/src/main/java/sprouts/impl/PropertyLens.java
@@ -4,6 +4,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import sprouts.*;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -39,6 +40,15 @@ import java.util.function.Function;
  * The source-specific behavior (single parent vs. dual parents) is encapsulated
  * in a {@link LensCore} implementation, making this class a unified wrapper
  * for all lens property variants.
+ * <p>
+ * <b>Note that this class is not limited to lenses.</b> Everything a lens property needs
+ * beyond the lens pattern itself &mdash; deriving an item from an arbitrary number of source
+ * properties, recomputing it whenever any of them changes, degrading to the last known item
+ * when that recomputation fails, and observing all of the sources through weak listeners
+ * &mdash; is exactly what a composite view needs as well. A {@link CompositeCore} therefore
+ * turns this class into the read-only composite view behind
+ * {@link sprouts.Viewable#of(Object, Function)}, in which case it reports itself as a view
+ * instead of a lens (see {@link LensCore#isView()}).
  *
  * @param <T> The type of the value, which is expected to be an immutable data carrier,
  *            such as a record, value object, or a primitive.
@@ -343,6 +353,45 @@ final class PropertyLens<T extends @Nullable Object> implements Var<T>, Viewable
         return new PropertyLens<>(type, Sprouts.factory().defaultId(), true, initialValue, core, null);
     }
 
+    // ==================== Composite factory method ====================
+
+    /**
+     * Creates a read-only composite view which folds the items of an arbitrary number of
+     * joined properties into a single item, starting at the supplied {@code seed}.
+     * <p>
+     * Deriving a composite view fails fast: if the initial fold cannot produce an item,
+     * because a combiner returned {@code null} or threw an exception, then this method throws
+     * a {@link NullPointerException} instead of handing out a view which cannot honour its
+     * promise of never holding {@code null}. Once the view is live, the very same failures
+     * merely make it retain its last item (see {@link CompositeCore#fetchFromSources(Object, boolean)}).
+     * <p>
+     * If no property is joined at all, or if every joined property is immutable, then the
+     * composite item can never change, and so an immutable property is returned instead of a
+     * live view.
+     */
+    static <C> Viewable<C> ofComposite( Class<C> type, C seed, List<CompositeCore.Join<C, ?>> joins ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(seed);
+        CompositeCore<C> core = new CompositeCore<>(type, seed, joins);
+        /*
+            The initial fold is the one place where we may not degrade to a last known item,
+            simply because there is none yet. So we let the core log whatever went wrong and
+            then reject the null it had to fall back to.
+        */
+        @Nullable C initialItem = core.fetchFromSources(null, true);
+        if ( initialItem == null )
+            throw new NullPointerException(
+                "Failed to compute the initial item of a composite view, because one of its " +
+                "combiners returned null or threw an exception. A composite view does not allow " +
+                "null items, so it cannot be created from a fold which does not produce an item."
+            );
+
+        if ( !core.sources().iterator().hasNext() )
+            return Viewable.cast(Property.of(true, type, initialItem)); // Nothing can ever change it.
+
+        return new PropertyLens<>(type, Sprouts.factory().defaultId(), false, initialItem, core, null);
+    }
+
     // ==================== Instance fields ====================
 
     private final PropertyChangeListeners<T> _changeListeners;
@@ -408,7 +457,7 @@ final class PropertyLens<T extends @Nullable Object> implements Var<T>, Viewable
      *  focused field would spam an error log on every read for as long as it stays null.
      */
     private @Nullable T _fetchFromSources(boolean logDegradation) {
-        @Nullable T fetched = _core.fetchFromSources(_lastItem);
+        @Nullable T fetched = _core.fetchFromSources(_lastItem, logDegradation);
         if ( fetched == null && !_nullable ) {
             if ( logDegradation )
                 _logError(
@@ -456,12 +505,12 @@ final class PropertyLens<T extends @Nullable Object> implements Var<T>, Viewable
 
     @Override
     public boolean isLens() {
-        return true;
+        return !_core.isView();
     }
 
     @Override
     public boolean isView() {
-        return false;
+        return _core.isView();
     }
 
     @Override
@@ -513,6 +562,16 @@ final class PropertyLens<T extends @Nullable Object> implements Var<T>, Viewable
     @Override
     public final Var<T> set( Channel channel, T newItem ) {
         Objects.requireNonNull(channel);
+        /*
+            Rejected up front, and not only down in the core: _setInternal() records the new item
+            as the fallback for failed recomputations before it writes to the sources, so letting
+            a read-only core fail down there would leave an item behind which was never really set.
+        */
+        if ( _core.isView() )
+            throw new UnsupportedOperationException(
+                "The '" + _core.coreName() + "' property is read-only! " +
+                "Change one of the properties it is derived from instead."
+            );
         ItemPair<T> pair = _setInternal(channel, newItem);
         if ( pair.change() != SingleChange.NONE )
             this.fireChange(channel, pair);

--- a/src/main/java/sprouts/impl/PropertyLens.java
+++ b/src/main/java/sprouts/impl/PropertyLens.java
@@ -4,7 +4,6 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import sprouts.*;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -369,7 +368,7 @@ final class PropertyLens<T extends @Nullable Object> implements Var<T>, Viewable
      * composite item can never change, and so an immutable property is returned instead of a
      * live view.
      */
-    static <C> Viewable<C> ofComposite( Class<C> type, C seed, List<CompositeCore.Join<C, ?>> joins ) {
+    static <C> Viewable<C> ofComposite( Class<C> type, C seed, Tuple<CompositeCore.Join<C, ?>> joins ) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(seed);
         CompositeCore<C> core = new CompositeCore<>(type, seed, joins);

--- a/src/main/java/sprouts/impl/SingleLensCore.java
+++ b/src/main/java/sprouts/impl/SingleLensCore.java
@@ -31,18 +31,20 @@ final class SingleLensCore<A extends @Nullable Object, T extends @Nullable Objec
     }
 
     @Override
-    public @Nullable T fetchFromSources(@Nullable T lastKnownItem) {
+    public @Nullable T fetchFromSources(@Nullable T lastKnownItem, boolean logDegradation) {
         T fetchedValue = lastKnownItem;
         try {
             fetchedValue = _lens.getter(Util.fakeNonNull(_parent.orElseNull()));
         } catch ( Exception e ) {
             Util.sneakyThrowExceptionIfFatal(e);
-            String parentId = _parent.id().isEmpty() ? "?" : "'" + _parent.id() + "'";
-            Util._logError(log,
-                    "Failed to fetch item for property lens from parent " +
-                    "property {} (with item type '{}') using the current lens getter.",
-                    parentId, _parent.type(), e
-            );
+            if ( logDegradation ) {
+                String parentId = _parent.id().isEmpty() ? "?" : "'" + _parent.id() + "'";
+                Util._logError(log,
+                        "Failed to fetch item for property lens from parent " +
+                        "property {} (with item type '{}') using the current lens getter.",
+                        parentId, _parent.type(), e
+                );
+            }
         }
         return fetchedValue;
     }

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -161,6 +161,18 @@ public final class Sprouts implements SproutsFactory
     }
 
     @Override
+    public <C> Viewable<C> viewOf(
+        Class<C> type,
+        C seed,
+        Function<Viewable.CompositeBuilder<C>, Viewable.CompositeBuilder<C>> configurator
+    ) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(seed);
+        Objects.requireNonNull(configurator);
+        throw new UnsupportedOperationException("Composite view building is not implemented yet!");
+    }
+
+    @Override
     public <T> Viewables<T> viewOf(Vals<T> source) {
         Objects.requireNonNull(source);
         return Viewables.cast(source); // TODO: Implement

--- a/src/main/java/sprouts/impl/Sprouts.java
+++ b/src/main/java/sprouts/impl/Sprouts.java
@@ -166,10 +166,23 @@ public final class Sprouts implements SproutsFactory
         C seed,
         Function<Viewable.CompositeBuilder<C>, Viewable.CompositeBuilder<C>> configurator
     ) {
-        Objects.requireNonNull(type);
-        Objects.requireNonNull(seed);
-        Objects.requireNonNull(configurator);
-        throw new UnsupportedOperationException("Composite view building is not implemented yet!");
+        Objects.requireNonNull(type, "The item type of a composite view must not be null.");
+        Objects.requireNonNull(seed, "The seed item of a composite view must not be null.");
+        Objects.requireNonNull(configurator, "The configurator of a composite view must not be null.");
+        if ( !type.isInstance(seed) )
+            throw new IllegalArgumentException(
+                "The seed item of type '"+seed.getClass()+"' does not fit the " +
+                "declared item type '"+type+"' of the composite view."
+            );
+        Viewable.CompositeBuilder<C> configured = configurator.apply(CompositeBuilderImpl.empty());
+        Objects.requireNonNull(configured, "The configurator of a composite view must not return null.");
+        if ( !(configured instanceof CompositeBuilderImpl) )
+            throw new IllegalArgumentException(
+                "The configurator of a composite view returned a foreign builder implementation " +
+                "of type '"+configured.getClass()+"'. Please return the builder produced by the " +
+                "'join(..)' calls on the supplied builder instead."
+            );
+        return PropertyLens.ofComposite(type, seed, ((CompositeBuilderImpl<C>) configured).joins());
     }
 
     @Override

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -321,6 +321,29 @@ public interface SproutsFactory
     <T extends @Nullable Object, U extends @Nullable Object, R> Viewable<@Nullable R> viewOfNullable(Class<R> type, Val<T> first, Val<U> second, BiFunction<T, U, @Nullable R> combiner);
 
     /**
+     *  Creates a non-nullable {@link Viewable} instance which is a composite of an arbitrary number
+     *  of {@link Val} instances, which are supplied to the {@link Viewable.CompositeBuilder} handed
+     *  to the given {@code configurator} function. The item of the resulting {@link Viewable} is
+     *  folded together, starting at the supplied {@code seed} and then applying the combiner of every
+     *  join in the order in which they were declared.
+     *
+     * @param type The type of the resulting {@link Viewable}.
+     * @param seed The initial item the fold of the composite starts at.
+     * @param configurator A function which declares the joined properties on the supplied builder
+     *                     and returns the resulting builder.
+     * @return A {@link Viewable} instance which is a live composite of the joined properties.
+     * @param <C> The type of the resulting {@link Viewable}.
+     * @throws NullPointerException if any of the supplied parameters are {@code null}, or if the
+     *                              supplied {@code configurator} returns {@code null}, or if the
+     *                              initial fold does not produce an item.
+     */
+    <C> Viewable<C> viewOf(
+        Class<C> type,
+        C seed,
+        Function<Viewable.CompositeBuilder<C>, Viewable.CompositeBuilder<C>> configurator
+    );
+
+    /**
      *  Creates a {@link Viewables} instance of the given {@link Vals}.
      *  You can register observers on the returned {@link Viewables} to receive updates
      *  when the items in the {@link Vals} change.

--- a/src/main/java/sprouts/impl/SproutsFactory.java
+++ b/src/main/java/sprouts/impl/SproutsFactory.java
@@ -336,6 +336,9 @@ public interface SproutsFactory
      * @throws NullPointerException if any of the supplied parameters are {@code null}, or if the
      *                              supplied {@code configurator} returns {@code null}, or if the
      *                              initial fold does not produce an item.
+     * @throws IllegalArgumentException if the supplied {@code seed} is not an instance of the supplied
+     *                                  {@code type}, or if the supplied {@code configurator} returns a
+     *                                  builder which did not originate from the one it was supplied with.
      */
     <C> Viewable<C> viewOf(
         Class<C> type,

--- a/src/main/java/sprouts/impl/TransientParentRef.java
+++ b/src/main/java/sprouts/impl/TransientParentRef.java
@@ -6,11 +6,27 @@ import sprouts.Val;
 import java.lang.ref.WeakReference;
 import java.util.Objects;
 
+/**
+ *  A {@link ParentRef} which holds its parent property weakly, so that observing a property
+ *  never keeps it alive, together with the last item that parent was seen holding.
+ *  <p>
+ *  Once the parent is garbage collected, a frozen stand-in property carrying that last item
+ *  is handed out in its place, which is what lets a view or lens keep deriving its own item
+ *  instead of breaking.
+ */
 final class TransientParentRef<V extends Val<?>> implements ParentRef<V>
 {
     private final WeakReference<V> _ref;
     private final Class<?>         _lastType;
-    private final @Nullable Object _lastItem;
+
+    /*
+        Deliberately mutable: this is the item the frozen stand-in above will carry, and it
+        has to keep up with the parent for as long as the parent is still alive. Freezing the
+        item captured when the parent was first referenced would make a collected parent
+        contribute the item it held back then, which means the item derived from it would
+        silently travel backwards in time the moment the parent is collected.
+     */
+    private @Nullable Object _lastItem;
 
     public TransientParentRef( WeakReference<V> ref, Class<?> lastType, @Nullable Object item ) {
         _ref      = Objects.requireNonNull(ref);
@@ -23,6 +39,12 @@ final class TransientParentRef<V extends Val<?>> implements ParentRef<V>
         @Nullable V current = _ref.get();
         if ( current == null )
             return (V) Property.ofNullable(false, (Class) _lastType, _lastItem);
+        /*
+            Every look at a live parent doubles as a chance to memorize what it holds.
+            This is what keeps the fallback current, and it is why this has to happen here,
+            in the one place every consumer of a weakly referenced parent has to go through.
+         */
+        _lastItem = current.orElseNull();
         return current;
     }
 }

--- a/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
@@ -950,17 +950,20 @@ class Composite_View_Building_Spec extends Specification
             strongly.get().city() == "Graz"
     }
 
-    def 'A composite view keeps the properties it joined alive.'()
+    def 'A composite view keeps the views it joined alive.'()
     {
         reportInfo """
             A property only holds a weak reference to the views derived from it, which is
             what makes views memory leak safe. But that also means somebody has to keep
             an intermediate view alive for as long as it is needed.
 
-            A composite view does exactly that: the reference from a property to the
-            composite view observing it is weak, but the reference from a composite view to
-            the properties it joined is *strong*. So you may create views and lenses inline
-            inside the configurator without having to store them yourself.
+            A composite view does exactly that: it references a joined view or lens
+            *strongly*, so that you may create intermediate properties inline inside the
+            configurator without having to store them yourself.
+
+            Note that this does **not** apply to plain properties, which a composite view
+            references weakly, exactly like every other view does. Have a look at the
+            "Composite View Memory Safety" specification for the full picture.
         """
         given : 'A regular property which we reference strongly.'
             var city = Var.of("Vienna")
@@ -1020,6 +1023,253 @@ class Composite_View_Building_Spec extends Specification
             temperature.set(30d)
         then : 'The composite view does not notice at all.'
             weather.get() == new Weather("Vienna", 0d, 0, false, "")
+    }
+
+    def 'Give a composite view an id using the `withId(..)` method.'()
+    {
+        reportInfo """
+            A composite view has no id by default, but just like any other property you can
+            derive a named copy of it through the `withId(..)` method. The named copy folds
+            the very same properties, which means it is a live view in its own right.
+        """
+        given : 'A property and a composite view built from it.'
+            var city = Var.of("Vienna")
+            var weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+        and : 'A named copy of the composite view.'
+            var named = weather.withId("weather")
+
+        expect : 'The copy carries the id, while the original still has none.'
+            named.id() == "weather"
+            weather.id() == ""
+        and : 'Both of them hold the same item.'
+            named.get() == weather.get()
+
+        when : 'We change the joined property.'
+            city.set("Graz")
+        then : 'Both the original and the named copy are updated.'
+            weather.get().city() == "Graz"
+            named.get().city() == "Graz"
+    }
+
+    def 'A composite view has a descriptive string representation.'()
+    {
+        reportInfo """
+            The `toString()` method of a composite view tells you that you are looking at a
+            view, together with the item type and the current item. If the view has an id,
+            then that is part of the string representation as well.
+        """
+        given : 'A property and a composite view built from it.'
+            var city = Var.of("Vienna")
+            var weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+
+        expect : 'The composite view presents itself as a view of the seed type.'
+            weather.toString().startsWith("View<Weather>[")
+            weather.toString().contains("city=Vienna")
+        and : 'A named composite view mentions its id as well.'
+            weather.withId("weather").toString().startsWith("View<Weather>[weather=")
+
+        when : 'We change the joined property.'
+            city.set("Graz")
+        then : 'The string representation reflects the new item.'
+            weather.toString().contains("city=Graz")
+    }
+
+    def 'You can fire a change event on a composite view manually.'()
+    {
+        reportInfo """
+            Sometimes you want to notify the observers of a composite view even though nothing
+            changed, which is what the `fireChange(Channel)` method inherited from `Val` is for.
+        """
+        given : 'A property and a composite view built from it.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+        and : 'A trace of all the change events of the composite view.'
+            var trace = []
+            weather.onChange(From.ALL, { trace << it.change() })
+
+        when : 'We fire a change event on the composite view itself.'
+            weather.fireChange(From.ALL)
+        then : 'The observers were notified, even though nothing changed.'
+            trace == [SingleChange.NONE]
+        and : 'The item of the composite view is of course unchanged.'
+            weather.get() == new Weather("Vienna", 0d, 0, false, "")
+    }
+
+    def 'You can unsubscribe the observers of a composite view.'()
+    {
+        reportInfo """
+            The observers of a composite view can be removed individually through
+            `unsubscribe(Subscriber)`, or all at once through `unsubscribeAll()`,
+            exactly like on any other `Viewable`.
+        """
+        given : 'A property and a composite view built from it.'
+            var city = Var.of("Vienna")
+            var weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+        and : 'Two observers writing into their own trace.'
+            var traceA = []
+            var traceB = []
+            Action<ValDelegate<Weather>> observerA = { traceA << it.currentValue().orElseNull().city() }
+            Action<ValDelegate<Weather>> observerB = { traceB << it.currentValue().orElseNull().city() }
+            weather.onChange(From.ALL, observerA)
+            weather.onChange(From.ALL, observerB)
+        expect : 'The composite view has two observers.'
+            weather.numberOfChangeListeners() == 2
+
+        when : 'We change the joined property.'
+            city.set("Graz")
+        then : 'Both observers were notified.'
+            traceA == ["Graz"]
+            traceB == ["Graz"]
+
+        when : 'We unsubscribe the first observer and change the property again.'
+            weather.unsubscribe(observerA)
+            city.set("Linz")
+        then : 'Only the second observer was notified.'
+            weather.numberOfChangeListeners() == 1
+            traceA == ["Graz"]
+            traceB == ["Graz", "Linz"]
+
+        when : 'We unsubscribe everything and change the property one last time.'
+            weather.unsubscribeAll()
+            city.set("Salzburg")
+        then : 'Nothing is notified anymore.'
+            weather.numberOfChangeListeners() == 0
+            traceA == ["Graz"]
+            traceB == ["Graz", "Linz"]
+    }
+
+    def 'A composite view can be observed through a simple `Observer`.'()
+    {
+        reportInfo """
+            Besides the `onChange(Channel, Action)` method, a composite view is also a plain
+            `Observable`, which means you can subscribe an `Observer` to it if you are only
+            interested in the fact that something changed, and not in what exactly.
+        """
+        given : 'A property and a composite view built from it.'
+            var city = Var.of("Vienna")
+            var weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+        and : 'An observer counting how often the composite view changed.'
+            var count = 0
+            weather.subscribe({ count++ } as Observer)
+
+        when : 'We change the joined property twice.'
+            city.set("Graz")
+            city.set("Linz")
+        then : 'The observer was notified twice.'
+            count == 2
+
+        when : 'We set the property to the item it already holds.'
+            city.set("Linz")
+        then : 'Nothing happened, because the composite item did not change.'
+            count == 2
+    }
+
+    def 'You can create ordinary property views from a composite view.'()
+    {
+        reportInfo """
+            A composite view is an ordinary `Viewable`, so all the usual view methods work on
+            it as well. This is how you narrow a large composite item back down to the single
+            value some part of your user interface actually needs.
+        """
+        given : 'Two properties merged into a composite view.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(55)
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+        and : 'A couple of ordinary views derived from the composite view.'
+            Viewable<String>  summary = weather.viewAsString( w -> w.city() + " @ " + w.humidity() + "%" )
+            Viewable<Boolean> humid   = weather.viewAs( Boolean.class, w -> w.humidity() > 50 )
+
+        expect : 'The derived views hold what the composite item says.'
+            summary.get() == "Vienna @ 55%"
+            humid.get() == true
+
+        when : 'We change one of the properties the composite view was folded from.'
+            humidity.set(30)
+        then : 'The change propagates through the composite view into the derived views.'
+            summary.get() == "Vienna @ 30%"
+            humid.get() == false
+    }
+
+    def 'A composite view tolerates changes made from within its own observers.'()
+    {
+        reportInfo """
+            An observer of a composite view may very well change one of the properties that
+            same composite view was folded from. Such a re-entrant change simply triggers
+            another recomputation, and as long as your observer eventually stops changing
+            things, the composite view settles on a consistent item.
+        """
+        given : 'Two properties merged into a composite view.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(0)
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+        and : 'An observer which keeps raising the humidity until it reaches 3.'
+            weather.onChange(From.ALL, {
+                if ( it.currentValue().orElseNull().humidity() < 3 )
+                    humidity.set(humidity.get() + 1)
+            })
+
+        when : 'We change the other property, which sets the whole cascade in motion.'
+            city.set("Graz")
+        then : 'No exception escaped, and the recursion terminated.'
+            noExceptionThrown()
+        and : 'The composite view settled on a consistent item.'
+            weather.get() == new Weather("Graz", 0d, 3, false, "")
+        and : 'The properties it was folded from agree with it.'
+            city.get() == "Graz"
+            humidity.get() == 3
+    }
+
+    def 'An immutable composite view built with an explicit type keeps that type.'()
+    {
+        reportInfo """
+            The collapse of a composite view into an immutable property does not lose the
+            type you declared: an immutable composite view built through the `Class` based
+            factory method reports the declared type, and not the concrete type of the seed.
+        """
+        given : 'A composite view of a polymorphic type which joins nothing at all.'
+            Viewable<Shape> shape = Viewable.of(Shape.class, new Rect(1d, 1d), it -> it)
+
+        expect : 'It collapsed into an immutable property...'
+            shape.isImmutable()
+        and : '...which nevertheless reports the declared supertype.'
+            shape.type() == Shape
+            shape.get() == new Rect(1d, 1d)
+    }
+
+    def 'A seed which does not fit the declared type is rejected.'()
+    {
+        reportInfo """
+            The `Class` based factory method declares the item type of the composite view,
+            so a seed which is not an instance of that type could never be folded into a
+            valid item and is rejected right away.
+        """
+        when : 'We try to build a composite view whose seed does not fit the declared type.'
+            Viewable.of(Shape.class, "I am not a shape", it -> it)
+        then : 'The attempt is rejected.'
+            var exception = thrown(IllegalArgumentException)
+        and : 'The error message explains the mismatch.'
+            exception.message.contains("Shape")
+    }
+
+    def 'The configurator has to return the builder it was given.'()
+    {
+        reportInfo """
+            The `Viewable.CompositeBuilder` handed to your configurator is the only builder a
+            composite view can be built from, because it is the one collecting your joins.
+            Returning some other implementation of the interface is therefore rejected.
+        """
+        when : 'We return a foreign builder implementation from the configurator.'
+            Viewable.of(Weather.blank(), it -> ({ property, combiner -> null } as Viewable.CompositeBuilder))
+        then : 'The attempt is rejected.'
+            var exception = thrown(IllegalArgumentException)
+        and : 'The error message tells us what to do instead.'
+            exception.message.contains("join")
     }
 
     /**

--- a/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
@@ -213,6 +213,10 @@ class Composite_View_Building_Spec extends Specification
             A property is not required to be joined only once. Every `join` call is an
             independent contribution to the fold, which means you can derive several
             parts of the composite item from a single property.
+
+            The property itself is still observed only once though: the fold reads the
+            current item of every join anyway, so a second listener on the same property
+            would merely recompute the very same item a second time.
         """
         given : 'A single property...'
             var city = Var.of("Vienna")
@@ -222,16 +226,26 @@ class Composite_View_Building_Spec extends Specification
                     .join(city, (w, c) -> w.withHumidity(c.length()))
                     .join(city, (w, c) -> w.withAlert(c.startsWith("V")))
                 )
+        and : 'A trace of the change events fired by the composite view.'
+            var trace = []
+            weather.onChange(From.ALL, { trace << it.currentValue().orElseNull() })
 
         expect : 'All three combiners contributed to the composite item.'
             weather.get() == new Weather("Vienna", 0d, 6, true, "")
-        and : 'Each join registered its own change listener on the property.'
-            city.numberOfChangeListeners() == 3
+        and : 'The property joined three times is still observed by a single listener.'
+            city.numberOfChangeListeners() == 1
 
         when : 'We change the property.'
             city.set("Graz")
-        then : 'All three parts of the composite item are updated.'
+        then : 'All three parts of the composite item are updated...'
             weather.get() == new Weather("Graz", 0d, 4, false, "")
+        and : '...through exactly one change event, and not one per join.'
+            trace == [new Weather("Graz", 0d, 4, false, "")]
+
+        when : 'We force a change event on the property, without actually changing it.'
+            city.fireChange(From.ALL)
+        then : 'The composite view also propagates that one exactly once.'
+            trace == [new Weather("Graz", 0d, 4, false, ""), new Weather("Graz", 0d, 4, false, "")]
     }
 
     def 'A composite view without any joins is an immutable property holding the seed.'()

--- a/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
@@ -1,0 +1,1012 @@
+package sprouts
+
+import spock.lang.Narrative
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Title
+
+import java.lang.ref.WeakReference
+
+@Title('Building Composite Views from Many Properties')
+@Narrative('''
+
+    The `Viewable.of(Val, Val, BiFunction)` factory methods let you merge exactly two
+    properties into a single live view. That is enough for a full name built from a
+    forename and a surname, but it does not scale: merging ten properties this way
+    means nesting nine composite views inside each other, each of which you have to
+    keep referenced, and whose combiner types quickly become unreadable.
+
+    This specification covers the scalable alternative: a composite view built from a
+    seed item and a chain of `join(..)` calls, where every `join` contributes one
+    property and one "wither" style combiner which folds the item of that property
+    into the composite item:
+
+    ```java
+    Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+            .join(cityProperty,        Weather::withCity)
+            .join(temperatureProperty, Weather::withTemperature)
+            .join(humidityProperty,    Weather::withHumidity)
+        );
+    ```
+
+    The item of such a composite view is always recomputed as a whole: the fold starts
+    at the seed and applies every combiner in `join` order, reading the *current* item
+    of every joined property. It never holds `null`, it degrades gracefully instead of
+    throwing when a combiner misbehaves, and just like every other view, it is only
+    weakly referenced by the properties it observes.
+
+''')
+@Subject([Viewable, Viewable.CompositeBuilder, Val, Var])
+class Composite_View_Building_Spec extends Specification
+{
+    static record Weather(
+        String  city,
+        double  temperature,
+        int     humidity,
+        boolean alert,
+        String  source
+    ) {
+        static Weather blank() { return new Weather("", 0d, 0, false, "") }
+        Weather withCity( String city ) { return new Weather(city, this.temperature, this.humidity, this.alert, this.source) }
+        Weather withTemperature( double temperature ) { return new Weather(this.city, temperature, this.humidity, this.alert, this.source) }
+        Weather withHumidity( int humidity ) { return new Weather(this.city, this.temperature, humidity, this.alert, this.source) }
+        Weather withAlert( boolean alert ) { return new Weather(this.city, this.temperature, this.humidity, alert, this.source) }
+        Weather withSource( String source ) { return new Weather(this.city, this.temperature, this.humidity, this.alert, source) }
+    }
+
+    static record Tally( int total ) {
+        Tally withTotal( int total ) { return new Tally(total) }
+    }
+
+    interface Shape {}
+
+    static record Rect( double width, double height ) implements Shape {}
+
+    static record Circle( double radius ) implements Shape {}
+
+
+    def 'Use the composite builder to merge many properties into a single view.'()
+    {
+        reportInfo """
+            The `Viewable.of(C, Function)` factory method takes a seed item and a
+            configurator lambda which receives a `Viewable.CompositeBuilder`.
+            Every `join(..)` call on that builder contributes one property together with
+            a combiner which folds the item of that property into the composite item.
+
+            The resulting `Viewable` is a live view: whenever any of the joined properties
+            changes, the composite item is recomputed and the change is propagated
+            to the listeners of the composite view.
+
+            Note how this scales to any number of properties without any nesting.
+        """
+        given : 'A handful of individual properties, as you would find them in a view model.'
+            Var<String>  city        = Var.of("Vienna")
+            Var<Double>  temperature = Var.of(21.5d)
+            Var<Integer> humidity    = Var.of(55)
+            Var<Boolean> alert       = Var.of(false)
+            Var<String>  source      = Var.of("station-1")
+        and : 'We merge all five of them into a single composite view.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,        Weather::withCity)
+                    .join(temperature, Weather::withTemperature)
+                    .join(humidity,    Weather::withHumidity)
+                    .join(alert,       Weather::withAlert)
+                    .join(source,      Weather::withSource)
+                )
+
+        expect : 'The composite view immediately holds the merged item.'
+            weather.get() == new Weather("Vienna", 21.5d, 55, false, "station-1")
+        and : 'It is a live view of the joined properties, and it never holds null.'
+            weather.isView()
+            !weather.allowsNull()
+
+        when : 'We change one of the joined properties...'
+            temperature.set(28.5d)
+        then : '...only that part of the composite item is affected.'
+            weather.get() == new Weather("Vienna", 28.5d, 55, false, "station-1")
+
+        when : 'We change several of the joined properties...'
+            city.set("Graz")
+            alert.set(true)
+        then : '...the composite item reflects all of them.'
+            weather.get() == new Weather("Graz", 28.5d, 55, true, "station-1")
+    }
+
+    def 'A composite view is folded from its seed, so parts which are not joined keep the seed item.'()
+    {
+        reportInfo """
+            The item of a composite view is computed by starting at the seed and then
+            applying every combiner in `join` order. Any part of the seed which no
+            combiner ever touches therefore simply survives in the composite item.
+
+            This makes the seed the natural place to put constant or default state.
+        """
+        given : 'A single property and a seed which already carries some state.'
+            Var<String> city = Var.of("Vienna")
+            var seed = new Weather("", -1d, -1, true, "manual-entry")
+        and : 'A composite view which only joins the city property.'
+            Viewable<Weather> weather = Viewable.of(seed, it -> it.join(city, Weather::withCity))
+
+        expect : 'Only the city was replaced, everything else comes from the seed.'
+            weather.get() == new Weather("Vienna", -1d, -1, true, "manual-entry")
+
+        when : 'We change the joined property.'
+            city.set("Graz")
+        then : 'The un-joined parts of the seed are still intact.'
+            weather.get() == new Weather("Graz", -1d, -1, true, "manual-entry")
+    }
+
+    def 'Build a composite view from a dynamic number of properties.'()
+    {
+        reportInfo """
+            Because the join chain is expressed through a configurator lambda,
+            you are not restricted to a statically known set of properties.
+            You can loop over a collection of properties and join each of them,
+            which is the main reason this API exists.
+
+            This example also demonstrates the most important semantic guarantee of
+            a composite view: the item is **recomputed as a whole**, starting at the
+            seed, on every single change. An accumulating combiner like the one below
+            is only correct because of that. If the composite merely applied the
+            combiner of the property that changed to its current item, the sum would
+            drift further and further away from the truth with every change.
+        """
+        given : 'A dozen properties holding the numbers 1 to 12.'
+            var numbers = (1..12).collect({ Var.of(it) })
+        and : 'A composite view which sums all of them by joining them in a loop.'
+            Viewable<Tally> tally = Viewable.of(new Tally(0), { builder ->
+                    numbers.inject(builder, { b, number ->
+                        b.join(number, (t, n) -> t.withTotal(t.total() + n))
+                    })
+                })
+
+        expect : 'The composite view holds the sum of the numbers 1 to 12.'
+            tally.get() == new Tally(78)
+
+        when : 'We change the first of the twelve properties.'
+            numbers[0].set(100)
+        then : 'The sum is recomputed from scratch, and not incrementally accumulated.'
+            tally.get() == new Tally(177)
+
+        when : 'We change the last of the twelve properties as well.'
+            numbers[11].set(0)
+        then : 'The sum is still exactly right.'
+            tally.get() == new Tally(165)
+    }
+
+    def 'The order of the `join` calls defines the order in which the combiners are applied.'()
+    {
+        reportInfo """
+            The combiners of a composite view form a fold which is applied in the exact
+            order in which the properties were joined. So if two combiners write to the
+            same part of the composite item, then the one which was joined last wins.
+        """
+        given : 'Two properties which both want to determine the city of the weather item.'
+            Var<String> preferredCity = Var.of("Vienna")
+            Var<String> fallbackCity  = Var.of("Graz")
+        and : 'A composite view where the fallback is joined last...'
+            Viewable<Weather> fallbackWins = Viewable.of(Weather.blank(), it -> it
+                    .join(preferredCity, Weather::withCity)
+                    .join(fallbackCity,  Weather::withCity)
+                )
+        and : '...and another one where the preferred city is joined last.'
+            Viewable<Weather> preferredWins = Viewable.of(Weather.blank(), it -> it
+                    .join(fallbackCity,  Weather::withCity)
+                    .join(preferredCity, Weather::withCity)
+                )
+
+        expect : 'In both cases the combiner which was joined last determined the item.'
+            fallbackWins.get().city() == "Graz"
+            preferredWins.get().city() == "Vienna"
+
+        when : 'We change both properties.'
+            preferredCity.set("Linz")
+            fallbackCity.set("Salzburg")
+        then : 'The join order still decides.'
+            fallbackWins.get().city() == "Salzburg"
+            preferredWins.get().city() == "Linz"
+    }
+
+    def 'The same property may be joined more than once.'()
+    {
+        reportInfo """
+            A property is not required to be joined only once. Every `join` call is an
+            independent contribution to the fold, which means you can derive several
+            parts of the composite item from a single property.
+        """
+        given : 'A single property...'
+            var city = Var.of("Vienna")
+        and : 'A composite view which derives three different parts from it.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city, Weather::withCity)
+                    .join(city, (w, c) -> w.withHumidity(c.length()))
+                    .join(city, (w, c) -> w.withAlert(c.startsWith("V")))
+                )
+
+        expect : 'All three combiners contributed to the composite item.'
+            weather.get() == new Weather("Vienna", 0d, 6, true, "")
+        and : 'Each join registered its own change listener on the property.'
+            city.numberOfChangeListeners() == 3
+
+        when : 'We change the property.'
+            city.set("Graz")
+        then : 'All three parts of the composite item are updated.'
+            weather.get() == new Weather("Graz", 0d, 4, false, "")
+    }
+
+    def 'A composite view without any joins is an immutable property holding the seed.'()
+    {
+        reportInfo """
+            A configurator which does not join anything is perfectly legal.
+            Since there is nothing which could ever change the composite item,
+            the resulting property is simply an immutable property holding the seed.
+        """
+        given : 'A composite view which joins nothing at all.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it)
+
+        expect : 'It holds exactly the seed item.'
+            weather.get() == Weather.blank()
+        and : 'And it is an immutable property, because nothing can ever change it.'
+            weather.isImmutable()
+            !weather.allowsNull()
+            weather.type() == Weather
+    }
+
+    def 'A composite view of exclusively immutable properties is itself immutable.'()
+    {
+        reportInfo """
+            Views of immutable properties are immutable themselves, because their item
+            can never change. A composite view applies the same optimization:
+            if every joined property is immutable, then so is the composite.
+        """
+        given : 'Two immutable properties.'
+            Val<String>  city     = Val.of("Vienna")
+            Val<Integer> humidity = Val.of(55)
+        and : 'A composite view of the two of them.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+
+        expect : 'The composite item was computed eagerly...'
+            weather.get() == new Weather("Vienna", 0d, 55, false, "")
+        and : '...and the composite view is immutable, just like its sources.'
+            weather.isImmutable()
+    }
+
+    def 'A composite view of mutable and immutable properties only listens to the mutable ones.'()
+    {
+        reportInfo """
+            Joining an immutable property is a useful way to fold a constant into the
+            composite item. Since such a property can never change, the composite view
+            does not need to observe it at all.
+        """
+        given : 'One mutable and one immutable property.'
+            var city   = Var.of("Vienna")
+            var source = Val.of("station-1")
+        and : 'A composite view of both of them.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,   Weather::withCity)
+                    .join(source, Weather::withSource)
+                )
+
+        expect : 'The composite view is live, because one of its sources is mutable.'
+            weather.isView()
+            weather.get() == new Weather("Vienna", 0d, 0, false, "station-1")
+        and : 'Only the mutable property is observed.'
+            city.numberOfChangeListeners() == 1
+            source.numberOfChangeListeners() == 0
+
+        when : 'We change the mutable property.'
+            city.set("Graz")
+        then : 'The composite item is updated, and the constant is still folded in.'
+            weather.get() == new Weather("Graz", 0d, 0, false, "station-1")
+    }
+
+    def 'The item type of a composite view is the concrete type of its seed.'()
+    {
+        reportInfo """
+            The `Viewable.of(C, Function)` factory method has no way of knowing the
+            intended item type other than by looking at the seed. So the `type()` of the
+            resulting composite view is the concrete runtime class of the seed.
+        """
+        given : 'A property and a composite view built from a `Weather` seed.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+
+        expect : 'The type of the composite view is the type of the seed.'
+            weather.type() == Weather
+        and : 'The composite view has no id, just like any other view.'
+            weather.id() == ""
+    }
+
+    def 'Use the `Class` based factory method to create a composite view of a polymorphic type.'()
+    {
+        reportInfo """
+            When the item type of your composite view is polymorphic, then deriving the
+            type from the concrete class of the seed is not good enough: a combiner which
+            produces a sibling subtype would not fit into the composite view anymore.
+
+            The `Viewable.of(Class, C, Function)` factory method exists for exactly this
+            case: it pins the item type of the composite view to the supplied class,
+            so that any subtype of it may be stored.
+        """
+        given : 'A property which decides which kind of shape we want, and one for its size.'
+            Var<String> kind = Var.of("rect")
+            Var<Double> size = Var.of(2d)
+        and : 'A composite view whose item type is explicitly declared to be the `Shape` supertype.'
+            Viewable<Shape> shape = Viewable.of(Shape.class, new Rect(1d, 1d), it -> it
+                    .join(kind, (s, k) -> "circle" == k ? new Circle(1d) : new Rect(1d, 1d))
+                    .join(size, (s, v) -> s instanceof Circle ? new Circle(v) : new Rect(v, v))
+                )
+
+        expect : 'The composite view has the declared type, and not the type of the seed.'
+            shape.type() == Shape
+            shape.get() == new Rect(2d, 2d)
+
+        when : 'We switch to a completely different subtype of `Shape`.'
+            kind.set("circle")
+        then : 'The composite view happily accepts it.'
+            shape.get() == new Circle(2d)
+
+        when : 'We change the size of the circle.'
+            size.set(7d)
+        then : 'The composite item is updated as expected.'
+            shape.get() == new Circle(7d)
+    }
+
+    def 'A composite view retains its item when the fold produces an item of an incompatible type.'()
+    {
+        reportInfo """
+            This is the flip side of the previous feature: if you use the factory method
+            without an explicit type, and your combiners produce a sibling subtype of the
+            seed type, then the resulting item does not fit into the composite view.
+
+            A composite view treats this exactly like any other failed recomputation:
+            it logs the problem and retains its previous item instead of throwing at
+            whoever happened to change a joined property.
+        """
+        given : 'We capture the `System.err` stream so that we can inspect the log.'
+            var originalErr = System.err
+            var outputStream = new ByteArrayOutputStream()
+            System.err = new PrintStream(outputStream)
+        and : 'A property deciding the kind of shape, and a composite view without an explicit type.'
+            Var<String> kind = Var.of("rect")
+            Viewable<Shape> shape = Viewable.of(new Rect(1d, 1d), it -> it
+                    .join(kind, (s, k) -> "circle" == k ? new Circle(1d) : new Rect(1d, 1d))
+                )
+
+        expect : 'The type of the composite view was inferred from the seed, so it is too narrow.'
+            shape.type() == Rect
+            shape.get() == new Rect(1d, 1d)
+
+        when : 'We make the combiner produce a sibling subtype.'
+            kind.set("circle")
+        then : 'No exception reaches the caller...'
+            noExceptionThrown()
+        and : '...the composite view retained its previous item...'
+            shape.get() == new Rect(1d, 1d)
+        and : '...and the problem was logged.'
+            outputStream.toString().contains("Circle")
+
+        cleanup : 'We restore the original `System.err` stream.'
+            System.err = originalErr
+    }
+
+    def 'A composite view never allows null items.'()
+    {
+        reportInfo """
+            A composite view is built from a non-null seed and it can only ever hold
+            non-null items. This is a deliberate design decision: a view is intended to
+            be consumed by an application layer, where `null` leads to exceptions and
+            ultimately to a confusing user experience.
+        """
+        given : 'A property and a composite view built from it.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+
+        expect : 'The composite view does not allow null items.'
+            !weather.allowsNull()
+            weather.isPresent()
+            !weather.isEmpty()
+    }
+
+    def 'Joined properties may be nullable, in which case the combiners receive `null`.'()
+    {
+        reportInfo """
+            A composite view never holds `null` itself, but the properties it is composed
+            of may very well be nullable. Their items are handed to the combiners as they
+            are, which means a combiner has to be prepared to receive `null` when it is
+            joined to a nullable property.
+        """
+        given : 'A nullable property which is initially empty.'
+            Var<String> city = Var.ofNull(String)
+        and : 'A composite view whose combiner maps `null` to a placeholder.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city, (w, c) -> w.withCity(c == null ? "<unknown>" : c))
+                )
+
+        expect : 'The combiner was called with `null` and produced the placeholder.'
+            weather.get().city() == "<unknown>"
+        and : 'The composite view is not nullable, even though its source is.'
+            city.allowsNull()
+            !weather.allowsNull()
+
+        when : 'We give the nullable property an item.'
+            city.set("Vienna")
+        then : 'The composite item is updated.'
+            weather.get().city() == "Vienna"
+
+        when : 'We empty the nullable property again.'
+            city.set(null)
+        then : 'The combiner receives `null` once more and maps it back to the placeholder.'
+            weather.get().city() == "<unknown>"
+    }
+
+    def 'Creating a composite view whose initial fold produces `null` throws a `NullPointerException`.'()
+    {
+        reportInfo """
+            Sprouts distinguishes between two phases: *deriving* a property, which is
+            when the reactive graph is being built, and *propagating* an event, which is
+            when the graph is already live.
+
+            Deriving must fail fast: if a combiner returns `null` while the composite
+            view is being created, then the composite view could not possibly honour its
+            promise of never holding `null`, and so its creation fails immediately.
+        """
+        given : 'A property whose item makes the combiner below return `null`.'
+            Var<String> city = Var.of("")
+
+        when : 'We try to create a composite view with a combiner returning `null`.'
+            Viewable.of(Weather.blank(), it -> it
+                    .join(city, (w, c) -> c.isEmpty() ? null : w.withCity(c))
+                )
+        then : 'The creation of the composite view fails immediately.'
+            thrown(NullPointerException)
+    }
+
+    def 'Creating a composite view whose initial fold throws, throws a `NullPointerException` and logs the cause.'()
+    {
+        reportInfo """
+            Just like a combiner returning `null`, a combiner which throws while the
+            composite view is being created makes it impossible to compute an initial
+            item. The creation therefore fails fast as well, and the original exception
+            is logged so that you can find out what actually went wrong.
+        """
+        given : 'We capture the `System.err` stream so that we can inspect the log.'
+            var originalErr = System.err
+            var outputStream = new ByteArrayOutputStream()
+            System.err = new PrintStream(outputStream)
+        and : 'A nullable property which is empty, and a combiner which cannot handle that.'
+            Var<String> city = Var.ofNull(String)
+
+        when : 'We try to create a composite view with this null unaware combiner.'
+            Viewable.of(Weather.blank(), it -> it.join(city, (w, c) -> w.withCity(c.trim())))
+        then : 'The creation of the composite view fails immediately.'
+            thrown(NullPointerException)
+        and : 'The cause of the failure was logged.'
+            outputStream.toString().contains("NullPointerException")
+
+        cleanup : 'We restore the original `System.err` stream.'
+            System.err = originalErr
+    }
+
+    def 'A combiner returning `null` during a change is logged, and the composite view retains its item.'()
+    {
+        reportInfo """
+            While *deriving* a composite view fails fast, *propagating* a change must
+            degrade gracefully. A caller who merely changes a property does not expect
+            their control flow to be interrupted, and a view which is allowed to throw
+            at that point would leave the reactive graph in an inconsistent state.
+
+            So when a combiner returns `null` during a change, the composite view logs
+            the problem and keeps the last item it successfully computed.
+        """
+        given : 'We capture the `System.err` stream so that we can inspect the log.'
+            var originalErr = System.err
+            var outputStream = new ByteArrayOutputStream()
+            System.err = new PrintStream(outputStream)
+        and : 'A property and a composite view whose combiner returns `null` for empty strings.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city, (w, c) -> c.isEmpty() ? null : w.withCity(c))
+                )
+        expect : 'Initially everything is fine.'
+            weather.get().city() == "Vienna"
+            outputStream.toString().isEmpty()
+
+        when : 'We make the combiner return `null`.'
+            city.set("")
+        then : 'No exception reaches the caller...'
+            noExceptionThrown()
+        and : '...the composite view retained its previous item...'
+            weather.get().city() == "Vienna"
+        and : '...and the problem was logged.'
+            !outputStream.toString().isEmpty()
+
+        when : 'We give the property a usable item again.'
+            city.set("Graz")
+        then : 'The composite view recovers completely.'
+            weather.get().city() == "Graz"
+
+        cleanup : 'We restore the original `System.err` stream.'
+            System.err = originalErr
+    }
+
+    def 'A combiner throwing during a change is logged, and the composite view retains its item.'()
+    {
+        reportInfo """
+            An exception thrown by one of the combiners of a composite view is caught and
+            logged instead of interrupting the control flow of whoever changed the joined
+            property. The composite view keeps the last item it successfully computed.
+        """
+        given : 'We capture the `System.err` stream so that we can inspect the log.'
+            var originalErr = System.err
+            var outputStream = new ByteArrayOutputStream()
+            System.err = new PrintStream(outputStream)
+        and : 'A property and a composite view whose combiner validates its input.'
+            Var<Double> temperature = Var.of(21.5d)
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(temperature, (w, t) -> {
+                        if ( t < -273.15d )
+                            throw new IllegalArgumentException("Temperature below absolute zero!")
+                        return w.withTemperature(t)
+                    })
+                )
+        expect : 'Initially everything is fine.'
+            weather.get().temperature() == 21.5d
+            outputStream.toString().isEmpty()
+
+        when : 'We set an item which makes the combiner throw.'
+            temperature.set(-300d)
+        then : 'We do not notice any exception being thrown!'
+            noExceptionThrown()
+        and : 'The composite view still holds the last item it could compute.'
+            weather.get().temperature() == 21.5d
+        and : 'Looking at the log, we see that the exception was logged.'
+            outputStream.toString().contains("Temperature below absolute zero!")
+            outputStream.toString().contains("IllegalArgumentException")
+
+        cleanup : 'We restore the original `System.err` stream.'
+            System.err = originalErr
+    }
+
+    def 'The recomputation of a composite view is atomic.'()
+    {
+        reportInfo """
+            The item of a composite view is folded together from the seed through all of
+            the combiners. If one of these combiners fails, then the whole recomputation
+            is discarded, and *not* the partial result of the combiners which ran before
+            the failing one. A composite view is therefore never observed in a
+            half updated state.
+
+            This also demonstrates the other half of the "recompute from live items"
+            semantic: once the failing combiner succeeds again, the composite view
+            catches up with *all* of the joined properties at once, including the
+            changes it had to discard in the meantime.
+        """
+        given : 'Three properties, where the middle one feeds a combiner which can fail.'
+            Var<String>  city        = Var.of("Vienna")
+            Var<Double>  temperature = Var.of(21.5d)
+            Var<Integer> humidity    = Var.of(55)
+        and : 'A composite view which folds them in exactly that order.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city, Weather::withCity)
+                    .join(temperature, (w, t) -> {
+                        if ( t < -273.15d )
+                            throw new IllegalArgumentException("Temperature below absolute zero!")
+                        return w.withTemperature(t)
+                    })
+                    .join(humidity, Weather::withHumidity)
+                )
+        expect : 'Initially the composite view holds the merged item.'
+            weather.get() == new Weather("Vienna", 21.5d, 55, false, "")
+
+        when : 'We break the middle combiner.'
+            temperature.set(-300d)
+        then : 'The composite view retains its item entirely.'
+            weather.get() == new Weather("Vienna", 21.5d, 55, false, "")
+
+        when : """
+            We now change the property which is folded *before* the failing combiner.
+            If the fold were committed step by step, then the new city would leak into
+            the composite item even though the recomputation as a whole failed.
+        """
+            city.set("Graz")
+        then : 'Nothing at all changed about the composite item.'
+            weather.get() == new Weather("Vienna", 21.5d, 55, false, "")
+
+        when : 'We also change the property which is folded *after* the failing combiner.'
+            humidity.set(80)
+        then : 'The composite item is still completely untouched.'
+            weather.get() == new Weather("Vienna", 21.5d, 55, false, "")
+
+        when : 'We finally give the middle property a usable item again.'
+            temperature.set(19d)
+        then : 'The composite view catches up with all of the changes it had to discard.'
+            weather.get() == new Weather("Graz", 19d, 80, false, "")
+    }
+
+    def 'The composite view factory methods reject `null` arguments.'()
+    {
+        reportInfo """
+            None of the ingredients of a composite view may be `null`:
+            neither the seed, nor the type, nor the configurator, nor the property or
+            combiner of an individual join. And since the configurator is supposed to
+            return the builder it produced, returning `null` from it is rejected as well.
+        """
+        given : 'A property we can use for joining.'
+            Var<String> city = Var.of("Vienna")
+
+        when : 'We pass a null seed...'
+            Viewable.of(null, it -> it)
+        then : 'A null pointer exception is thrown.'
+            thrown(NullPointerException)
+
+        when : 'We pass a null configurator...'
+            Viewable.of(Weather.blank(), null)
+        then : 'A null pointer exception is thrown.'
+            thrown(NullPointerException)
+
+        when : 'We pass a null type...'
+            Viewable.of(null, Weather.blank(), it -> it)
+        then : 'A null pointer exception is thrown.'
+            thrown(NullPointerException)
+
+        when : 'We return null from the configurator...'
+            Viewable.of(Weather.blank(), it -> null)
+        then : 'A null pointer exception is thrown.'
+            thrown(NullPointerException)
+
+        when : 'We join a null property...'
+            Viewable.of(Weather.blank(), it -> it.join(null, Weather::withCity))
+        then : 'A null pointer exception is thrown.'
+            thrown(NullPointerException)
+
+        when : 'We join a null combiner...'
+            Viewable.of(Weather.blank(), it -> it.join(city, null))
+        then : 'A null pointer exception is thrown.'
+            thrown(NullPointerException)
+    }
+
+    def 'A composite view only fires a change event when its item actually changed.'()
+    {
+        reportInfo """
+            A composite view is not a mere event forwarder. It only notifies its own
+            listeners when the recomputed item actually differs from the previous one.
+            So a change in a joined property which does not survive the fold
+            stays invisible to the observers of the composite view.
+        """
+        given : 'A property holding a temperature in degrees celsius.'
+            Var<Integer> celsius = Var.of(20)
+        and : 'A composite view which merely derives an alert flag from it.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(celsius, (w, c) -> w.withAlert(c > 30))
+                )
+        and : 'A trace of all the change events of the composite view.'
+            var trace = []
+            weather.onChange(From.ALL, { trace << it.currentValue().orElseNull() })
+
+        when : 'We change the property to another item which still maps to the same flag.'
+            celsius.set(25)
+        then : 'The composite view did not fire a change event.'
+            trace.isEmpty()
+        and : 'Its item is indeed unchanged.'
+            weather.get() == new Weather("", 0d, 0, false, "")
+
+        when : 'We change the property so that the derived flag flips.'
+            celsius.set(35)
+        then : 'The composite view fired exactly one change event.'
+            trace == [new Weather("", 0d, 0, true, "")]
+    }
+
+    def 'A forced change event on a joined property is propagated by the composite view.'()
+    {
+        reportInfo """
+            Sometimes you want to notify the observers of a property even though its item
+            did not change, which is what the `fireChange(Channel)` method is for.
+            A composite view honours such a forced change event and passes it on to its
+            own observers, even though its item did not change either.
+        """
+        given : 'A property and a composite view built from it.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+        and : 'A trace of all the change events of the composite view.'
+            var trace = []
+            weather.onChange(From.ALL, { trace << it.change() })
+
+        when : 'We set the property to the very same item it already holds.'
+            city.set("Vienna")
+        then : 'Nothing happens at all.'
+            trace.isEmpty()
+
+        when : 'We force a change event on the joined property.'
+            city.fireChange(From.ALL)
+        then : 'The composite view forwarded the forced change event.'
+            trace == [SingleChange.NONE]
+        and : 'Its item is of course still the same.'
+            weather.get().city() == "Vienna"
+    }
+
+    def 'A composite view fires its change events on the channel of the originating change.'()
+    {
+        reportInfo """
+            A change of a joined property carries the `Channel` it originated from,
+            and a composite view preserves that information when it notifies its own
+            observers. This way an observer of a composite view can still distinguish
+            a change which came from the view layer from one which came from the
+            view model layer.
+        """
+        given : 'A property and a composite view built from it.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+        and : 'Three traces, one for each of the three standard channels.'
+            var all = []
+            var fromView = []
+            var fromViewModel = []
+            weather.onChange(From.ALL,        { all << it.channel() })
+            weather.onChange(From.VIEW,       { fromView << it.channel() })
+            weather.onChange(From.VIEW_MODEL, { fromViewModel << it.channel() })
+
+        when : 'We change the joined property through the view channel.'
+            city.set(From.VIEW, "Graz")
+        then : 'Only the observers of the view channel and of all channels were notified.'
+            all == [From.VIEW]
+            fromView == [From.VIEW]
+            fromViewModel == []
+
+        when : 'We change the joined property through the view model channel.'
+            city.set(From.VIEW_MODEL, "Linz")
+        then : 'Only the observers of the view model channel and of all channels were notified.'
+            all == [From.VIEW, From.VIEW_MODEL]
+            fromView == [From.VIEW]
+            fromViewModel == [From.VIEW_MODEL]
+    }
+
+    def 'A composite view of properties which share a common source is free of intermediate items.'()
+    {
+        reportInfo """
+            It is very common to join properties which are not actually independent of
+            each other, for example a property together with a view derived from it.
+            A naive implementation would then expose intermediate items to its observers:
+            one where the first property is already updated but the derived one is not.
+
+            A composite view avoids this entirely, because it never remembers the items
+            of its sources. Every recomputation reads the *current* item of every joined
+            property, and by the time a composite view is notified, all of its sources
+            have already been brought up to date.
+        """
+        given : 'A property, and a chain of two views derived from it.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Integer> nameLength = city.viewAsInt( c -> c.length() )
+            Viewable<Boolean> hasLongName = nameLength.viewAs( Boolean.class, n -> n > 5 )
+        and : 'A composite view joining the property together with both of its derived views.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,        Weather::withCity)
+                    .join(nameLength,  Weather::withHumidity)
+                    .join(hasLongName, Weather::withAlert)
+                )
+        and : 'A trace of all the change events of the composite view.'
+            var trace = []
+            weather.onChange(From.ALL, { trace << it.currentValue().orElseNull() })
+
+        expect : 'The composite view starts out consistent.'
+            weather.get() == new Weather("Vienna", 0d, 6, true, "")
+
+        when : 'We change the single property all three sources ultimately depend on.'
+            city.set("Graz")
+        then : 'Exactly one change event was fired, and it carries a fully consistent item.'
+            trace == [new Weather("Graz", 0d, 4, false, "")]
+        and : 'The composite view holds that same consistent item.'
+            weather.get() == new Weather("Graz", 0d, 4, false, "")
+    }
+
+    def 'Composite views can be joined into other composite views.'()
+    {
+        reportInfo """
+            A composite view is an ordinary `Viewable`, which means it can be used
+            wherever a `Val` is expected, including as a source of another composite view.
+            This lets you assemble large models out of smaller, independently
+            defined composites.
+        """
+        given : 'Two properties which are merged into a first composite view.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(55)
+            Viewable<Weather> location = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+        and : 'A second composite view which joins the first one together with another property.'
+            Var<Double> temperature = Var.of(21.5d)
+            Viewable<Weather> complete = Viewable.of(Weather.blank(), it -> it
+                    .join(location,    (w, l) -> w.withCity(l.city()).withHumidity(l.humidity()))
+                    .join(temperature, Weather::withTemperature)
+                )
+
+        expect : 'The outer composite view merged everything.'
+            complete.get() == new Weather("Vienna", 21.5d, 55, false, "")
+
+        when : 'We change a property of the inner composite view.'
+            city.set("Graz")
+        then : 'The change propagates all the way through both composite views.'
+            location.get().city() == "Graz"
+            complete.get() == new Weather("Graz", 21.5d, 55, false, "")
+
+        when : 'We change the property of the outer composite view.'
+            temperature.set(28d)
+        then : 'Only the outer composite view is affected.'
+            location.get() == new Weather("Graz", 0d, 55, false, "")
+            complete.get() == new Weather("Graz", 28d, 55, false, "")
+    }
+
+    def 'Every `join` registers exactly one change listener on the joined property.'()
+    {
+        reportInfo """
+            A composite view observes each joined property with a single change listener.
+            You can verify this through the number of change listeners reported by the
+            joined properties.
+        """
+        given : 'Three properties without any listeners.'
+            var city        = Var.of("Vienna")
+            var temperature = Var.of(21.5d)
+            var humidity    = Var.of(55)
+        expect : 'Initially there are no change listeners registered.'
+            city.numberOfChangeListeners() == 0
+            temperature.numberOfChangeListeners() == 0
+            humidity.numberOfChangeListeners() == 0
+
+        when : 'We create a composite view joining the first two properties.'
+            var weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,        Weather::withCity)
+                    .join(temperature, Weather::withTemperature)
+                )
+        then : 'Exactly the two joined properties are being observed.'
+            city.numberOfChangeListeners() == 1
+            temperature.numberOfChangeListeners() == 1
+            humidity.numberOfChangeListeners() == 0
+
+        when : 'We create a second composite view joining all three properties.'
+            var otherWeather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,        Weather::withCity)
+                    .join(temperature, Weather::withTemperature)
+                    .join(humidity,    Weather::withHumidity)
+                )
+        then : 'Each composite view contributes its own listeners.'
+            city.numberOfChangeListeners() == 2
+            temperature.numberOfChangeListeners() == 2
+            humidity.numberOfChangeListeners() == 1
+    }
+
+    def 'A composite view and its listeners are garbage collected when it is no longer referenced strongly.'()
+    {
+        reportInfo """
+            Just like every other view in Sprouts, a composite view is only weakly
+            referenced by the properties it observes. So when you stop referencing a
+            composite view, it becomes eligible for garbage collection together with all
+            of the change listeners registered on it, and the change listeners it
+            registered on its joined properties disappear as well.
+        """
+        given : 'Two properties without any listeners.'
+            var city     = Var.of("Vienna")
+            var humidity = Var.of(55)
+        expect : 'Initially there are no change listeners registered.'
+            city.numberOfChangeListeners() == 0
+            humidity.numberOfChangeListeners() == 0
+
+        when : 'We create a composite view which we reference strongly.'
+            var strongly = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+        then : 'Both joined properties are being observed.'
+            city.numberOfChangeListeners() == 1
+            humidity.numberOfChangeListeners() == 1
+
+        when : 'We create two more composite views which we do not reference strongly.'
+            Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity).join(humidity, Weather::withHumidity))
+            Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity).join(humidity, Weather::withHumidity))
+        and : 'We wait for the garbage collector to run.'
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+
+        then : 'Only the listeners of the strongly referenced composite view survived.'
+            city.numberOfChangeListeners() == 1
+            humidity.numberOfChangeListeners() == 1
+        and : 'The surviving composite view still works.'
+            strongly.get() == new Weather("Vienna", 0d, 55, false, "")
+
+        when : 'We change one of the joined properties.'
+            city.set("Graz")
+        then : 'The surviving composite view is updated.'
+            strongly.get().city() == "Graz"
+    }
+
+    def 'A composite view keeps the views it joined alive.'()
+    {
+        reportInfo """
+            A property only holds a weak reference to the views derived from it, which is
+            what makes views memory leak safe. But that also means somebody has to keep
+            an intermediate view alive for as long as it is needed.
+
+            A composite view does exactly that: it holds a *strong* reference to every
+            joined property which is itself a view or a lens, so that you may create
+            them inline inside the configurator without having to store them yourself.
+
+            Note that this does **not** apply to regular properties: a plain `Var` is only
+            weakly referenced by the composite view, so you still have to keep your
+            actual state alive yourself.
+        """
+        given : 'A regular property which we reference strongly.'
+            var city = Var.of("Vienna")
+        and : 'A composite view joining a view which is created inline and referenced nowhere else.'
+            var weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city.viewAsInt( c -> c.length() ), Weather::withHumidity)
+                )
+        expect : 'The inline view was folded into the composite item.'
+            weather.get().humidity() == 6
+
+        when : 'We wait for the garbage collector to run.'
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        then : 'The inline view was not collected, because the composite view keeps it alive.'
+            city.numberOfChangeListeners() == 1
+
+        when : 'We change the property the inline view is derived from.'
+            city.set("Sankt Poelten")
+        then : 'The composite view is updated through the still living inline view.'
+            weather.get().humidity() == 13
+    }
+
+    def 'The composite builder is immutable, so joins on an escaped builder have no effect.'()
+    {
+        reportInfo """
+            The `Viewable.CompositeBuilder` is an immutable value: every `join` call
+            returns a *new* builder instead of mutating the one it was called on, and no
+            change listener is registered before the configurator has returned.
+
+            This means a builder which escapes from the configurator is completely inert.
+            Calling `join` on it cannot retroactively modify an already created composite
+            view, and it cannot secretly register listeners on your properties either.
+        """
+        given : 'Two properties, of which we only intend to join the first one.'
+            var city        = Var.of("Vienna")
+            var temperature = Var.of(21.5d)
+        and : 'A composite view whose configurator lets the builder escape.'
+            var escaped = null
+            var weather = Viewable.of(Weather.blank(), { builder ->
+                    escaped = builder
+                    return builder.join(city, Weather::withCity)
+                })
+        expect : 'The composite view was built as expected.'
+            weather.get() == new Weather("Vienna", 0d, 0, false, "")
+            city.numberOfChangeListeners() == 1
+            temperature.numberOfChangeListeners() == 0
+
+        when : 'We use the escaped builder to join the second property after the fact.'
+            escaped.join(temperature, Weather::withTemperature)
+        then : 'No listener was registered on the second property.'
+            temperature.numberOfChangeListeners() == 0
+        and : 'The already created composite view is unaffected.'
+            weather.get() == new Weather("Vienna", 0d, 0, false, "")
+
+        when : 'We change the property which was never really joined.'
+            temperature.set(30d)
+        then : 'The composite view does not notice at all.'
+            weather.get() == new Weather("Vienna", 0d, 0, false, "")
+    }
+
+    /**
+     * This method guarantees that garbage collection is
+     * done unlike <code>{@link System#gc()}</code>
+     */
+    static void waitForGarbageCollection() {
+        Object obj = new Object()
+        WeakReference ref = new WeakReference<>(obj)
+        obj = null
+        while ( ref.get() != null ) {
+            System.gc()
+        }
+    }
+}

--- a/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_View_Building_Spec.groovy
@@ -411,6 +411,34 @@ class Composite_View_Building_Spec extends Specification
             !weather.isEmpty()
     }
 
+    def 'A composite view is read-only.'()
+    {
+        reportInfo """
+            A composite view is a `Viewable`, which is a read-only property type, so there is no
+            way to set its item through the API you are handed. Its item is defined entirely by
+            the seed and the properties it was folded from, and the way to change it is to change
+            one of those properties.
+
+            Should you circumvent the type system to set it anyway, then this is rejected
+            explicitly instead of silently corrupting the composite item.
+        """
+        given : 'A property and a composite view built from it.'
+            Var<String> city = Var.of("Vienna")
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+
+        when : 'We try to set the item of the composite view directly.'
+            (weather as Var<Weather>).set(new Weather("Graz", 1d, 2, true, "manual"))
+        then : 'The attempt is rejected.'
+            thrown(UnsupportedOperationException)
+        and : 'The composite view still holds the item it folded together.'
+            weather.get() == new Weather("Vienna", 0d, 0, false, "")
+
+        when : 'We change the property it was folded from instead.'
+            city.set("Graz")
+        then : 'The composite item is updated as expected.'
+            weather.get() == new Weather("Graz", 0d, 0, false, "")
+    }
+
     def 'Joined properties may be nullable, in which case the combiners receive `null`.'()
     {
         reportInfo """
@@ -922,20 +950,17 @@ class Composite_View_Building_Spec extends Specification
             strongly.get().city() == "Graz"
     }
 
-    def 'A composite view keeps the views it joined alive.'()
+    def 'A composite view keeps the properties it joined alive.'()
     {
         reportInfo """
             A property only holds a weak reference to the views derived from it, which is
             what makes views memory leak safe. But that also means somebody has to keep
             an intermediate view alive for as long as it is needed.
 
-            A composite view does exactly that: it holds a *strong* reference to every
-            joined property which is itself a view or a lens, so that you may create
-            them inline inside the configurator without having to store them yourself.
-
-            Note that this does **not** apply to regular properties: a plain `Var` is only
-            weakly referenced by the composite view, so you still have to keep your
-            actual state alive yourself.
+            A composite view does exactly that: the reference from a property to the
+            composite view observing it is weak, but the reference from a composite view to
+            the properties it joined is *strong*. So you may create views and lenses inline
+            inside the configurator without having to store them yourself.
         """
         given : 'A regular property which we reference strongly.'
             var city = Var.of("Vienna")

--- a/src/test/groovy/sprouts/Composite_View_Memory_Safety_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_View_Memory_Safety_Spec.groovy
@@ -155,6 +155,168 @@ class Composite_View_Memory_Safety_Spec extends Specification
             weather.get() == new Weather("Vienna", 0d, 80, false, "")
     }
 
+    def 'A collected property leaves behind the last item it held, not the one it was joined with.'()
+    {
+        reportInfo """
+            The "last known item" of a collected property really is the *last* one, and not
+            the one it happened to hold when it was joined. Anything else would make the
+            composite item travel backwards in time the moment a joined property is
+            collected, silently undoing changes which were already observed.
+        """
+        given : 'Two plain properties, one of which we will drop later.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(55)
+        and : 'A composite view of the two of them.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+        expect : 'It starts out with the items the properties were joined with.'
+            weather.get() == new Weather("Vienna", 0d, 55, false, "")
+
+        when : 'We change the first property several times *after* it was joined...'
+            city.set("Graz")
+            city.set("Linz")
+        then : 'The composite view follows along.'
+            weather.get() == new Weather("Linz", 0d, 55, false, "")
+
+        when : 'We now drop the property and await garbage collection.'
+            var cityRef = new WeakReference(city)
+            city = null
+            waitForGarbageCollection()
+        then : 'It was collected.'
+            cityRef.get() == null
+
+        when : 'We trigger a recomputation through the property which is still alive.'
+            humidity.set(80)
+        then : 'The fold contributed "Linz", the last item the collected property held.'
+            weather.get() == new Weather("Linz", 0d, 80, false, "")
+    }
+
+    def 'A property collected without the composite view ever being read leaves its last item behind.'()
+    {
+        reportInfo """
+            A composite view learns what its joined properties hold in two ways: by reading
+            them whenever its own item is computed, and by being notified when one of them
+            changes. The second one is what covers this scenario, where nobody ever reads
+            the composite view between the change and the garbage collection.
+        """
+        given : 'Two plain properties and a composite view of them, which we never read.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(55)
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+
+        when : 'We change the first property, without ever reading the composite view.'
+            city.set("Graz")
+        and : 'We drop the property and await garbage collection.'
+            var cityRef = new WeakReference(city)
+            city = null
+            waitForGarbageCollection()
+        then : 'It was collected.'
+            cityRef.get() == null
+
+        when : 'We read the composite view for the very first time.'
+            var folded = weather.get()
+        then : 'It knows about the change it was notified of, even though nobody read it.'
+            folded == new Weather("Graz", 0d, 55, false, "")
+    }
+
+    def 'A property joined several times contributes its last item to every one of its combiners.'()
+    {
+        reportInfo """
+            Joining a property more than once does not change any of this: after the property
+            is collected, every one of its combiners folds in the same last known item.
+        """
+        given : 'A property joined twice, and a second one to trigger recomputations with.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(0)
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(city,     (w, c) -> w.withSource("station-" + c))
+                    .join(humidity, Weather::withHumidity)
+                )
+        expect : 'Both combiners contributed.'
+            weather.get() == new Weather("Vienna", 0d, 0, false, "station-Vienna")
+
+        when : 'We change the doubly joined property and then drop it.'
+            city.set("Graz")
+            var cityRef = new WeakReference(city)
+            city = null
+            waitForGarbageCollection()
+        then : 'It was collected.'
+            cityRef.get() == null
+
+        when : 'We trigger a recomputation.'
+            humidity.set(80)
+        then : 'Both combiners folded in the last item, and neither of them fell back to "Vienna".'
+            weather.get() == new Weather("Graz", 0d, 80, false, "station-Graz")
+    }
+
+    def 'A nullable property which was emptied before being collected leaves `null` behind.'()
+    {
+        reportInfo """
+            The last known item of a collected property may very well be `null`, if that is
+            what the property held when it was last seen. A combiner joined to a nullable
+            property has to be prepared for `null` anyway, so this changes nothing for it.
+        """
+        given : 'A nullable property, a plain one, and a composite view of both.'
+            Var<String>  city     = Var.ofNullable(String, "Vienna")
+            Var<Integer> humidity = Var.of(55)
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     (w, c) -> w.withCity(c == null ? "<unknown>" : c))
+                    .join(humidity, Weather::withHumidity)
+                )
+        expect : 'The composite view folded the item of the nullable property in.'
+            weather.get().city() == "Vienna"
+
+        when : 'We empty the nullable property and then drop it.'
+            city.set(null)
+            var cityRef = new WeakReference(city)
+            city = null
+            waitForGarbageCollection()
+        then : 'It was collected.'
+            cityRef.get() == null
+
+        when : 'We trigger a recomputation.'
+            humidity.set(80)
+        then : 'The combiner received the `null` the property was last holding.'
+            weather.get() == new Weather("<unknown>", 0d, 80, false, "")
+    }
+
+    def 'A composite view whose joined properties were all collected freezes on its last item.'()
+    {
+        reportInfo """
+            Once every joined property is gone, there is nothing left which could ever change
+            the composite item. The view then simply keeps reporting the item it folded from
+            everything it last knew, instead of breaking or reverting.
+        """
+        given : 'Two plain properties and a composite view of them.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(55)
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+
+        when : 'We change both of them and then drop both of them.'
+            city.set("Graz")
+            humidity.set(80)
+            var refs = [new WeakReference(city), new WeakReference(humidity)]
+            city = null
+            humidity = null
+            waitForGarbageCollection()
+        then : 'Both were collected.'
+            refs.every( it -> it.get() == null )
+
+        and : 'The composite view still reports what it last folded together.'
+            weather.get() == new Weather("Graz", 0d, 80, false, "")
+        and : 'And it keeps doing so, no matter how often it is read.'
+            weather.get() == new Weather("Graz", 0d, 80, false, "")
+    }
+
     def 'A composite view keeps the views and lenses it joined alive.'()
     {
         reportInfo """

--- a/src/test/groovy/sprouts/Composite_View_Memory_Safety_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_View_Memory_Safety_Spec.groovy
@@ -24,8 +24,9 @@ import java.lang.ref.WeakReference
       properties created inline inside the configurator stay alive for as long as they
       are needed.
     * A composite view references a joined **plain property weakly**, so that observing
-      your state never keeps that state alive. Should such a property be collected, the
-      composite view keeps folding in its last known item instead of breaking.
+      your state never keeps that state alive. When such a property is garbage collected,
+      the composite view does not break: it keeps folding in the newest item it saw that
+      property holding, which is the item it held just before it was collected.
 
     This specification pins down all of these cases by checking which properties actually
     survive garbage collection, and which do not.
@@ -125,7 +126,7 @@ class Composite_View_Memory_Safety_Spec extends Specification
             still holding on to the composite view.
 
             The composite view does not break when that happens: it keeps folding in the
-            last known item of the collected property.
+            newest item it saw that property holding before it was garbage collected.
         """
         given : 'Two plain properties which we will dereference later.'
             Var<String>  city     = Var.of("Vienna")
@@ -155,15 +156,21 @@ class Composite_View_Memory_Safety_Spec extends Specification
             weather.get() == new Weather("Vienna", 0d, 80, false, "")
     }
 
-    def 'A collected property leaves behind the last item it held, not the one it was joined with.'()
+    def 'A garbage collected property contributes its newest item, and not the one it was joined with.'()
     {
         reportInfo """
-            The "last known item" of a collected property really is the *last* one, and not
-            the one it happened to hold when it was joined. Anything else would make the
-            composite item travel backwards in time the moment a joined property is
-            collected, silently undoing changes which were already observed.
+            A composite view only references a joined plain property weakly, which means the
+            property can be garbage collected while the view lives on. From that point on the
+            view has nothing left to read, so it keeps using the item it saw the property
+            holding the last time it looked at it.
+
+            The important word here is *last*. It must not be the item the property held back
+            when it was joined, because between the join and the garbage collection the
+            property may have changed many times, and the view already showed those changes.
+            Falling back to the item from join time would undo all of them at once, and the
+            composite item would jump back to a state which is already out of date.
         """
-        given : 'Two plain properties, one of which we will drop later.'
+        given : 'Two properties, one of which we will let the garbage collector take later on.'
             Var<String>  city     = Var.of("Vienna")
             Var<Integer> humidity = Var.of(55)
         and : 'A composite view of the two of them.'
@@ -171,37 +178,41 @@ class Composite_View_Memory_Safety_Spec extends Specification
                     .join(city,     Weather::withCity)
                     .join(humidity, Weather::withHumidity)
                 )
-        expect : 'It starts out with the items the properties were joined with.'
+        expect : 'The view starts out with the items the two properties were joined with.'
             weather.get() == new Weather("Vienna", 0d, 55, false, "")
 
-        when : 'We change the first property several times *after* it was joined...'
+        when : 'We change the city twice, long after it was joined.'
             city.set("Graz")
             city.set("Linz")
-        then : 'The composite view follows along.'
+        then : 'The view shows the newest city, so "Linz" is what it last saw.'
             weather.get() == new Weather("Linz", 0d, 55, false, "")
 
-        when : 'We now drop the property and await garbage collection.'
+        when : 'We now drop our only reference to the city property...'
             var cityRef = new WeakReference(city)
             city = null
+        and : 'We wait for the garbage collector to do its job.'
             waitForGarbageCollection()
-        then : 'It was collected.'
+        then : 'The city property is gone.'
             cityRef.get() == null
 
-        when : 'We trigger a recomputation through the property which is still alive.'
+        when : 'We change the humidity, which makes the view recompute its item.'
             humidity.set(80)
-        then : 'The fold contributed "Linz", the last item the collected property held.'
+        then : 'The view uses "Linz", the newest city, and does not fall back to "Vienna".'
             weather.get() == new Weather("Linz", 0d, 80, false, "")
     }
 
-    def 'A property collected without the composite view ever being read leaves its last item behind.'()
+    def 'A change is remembered even if nobody reads the composite view before the garbage collection.'()
     {
         reportInfo """
-            A composite view learns what its joined properties hold in two ways: by reading
-            them whenever its own item is computed, and by being notified when one of them
-            changes. The second one is what covers this scenario, where nobody ever reads
-            the composite view between the change and the garbage collection.
+            There are two moments at which a composite view can notice what a joined property
+            holds: when the view computes its own item, and when the property notifies the view
+            that it changed.
+
+            This scenario takes the first moment away completely, because the view is never
+            read between the change and the garbage collection. The notification alone has to
+            be enough for the view to remember the new item.
         """
-        given : 'Two plain properties and a composite view of them, which we never read.'
+        given : 'Two properties and a composite view of them, which we deliberately never read.'
             Var<String>  city     = Var.of("Vienna")
             Var<Integer> humidity = Var.of(55)
             Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
@@ -209,28 +220,29 @@ class Composite_View_Memory_Safety_Spec extends Specification
                     .join(humidity, Weather::withHumidity)
                 )
 
-        when : 'We change the first property, without ever reading the composite view.'
+        when : 'We change the city, without ever reading the composite view.'
             city.set("Graz")
-        and : 'We drop the property and await garbage collection.'
+        and : 'We drop our only reference to the city property and wait for the garbage collector.'
             var cityRef = new WeakReference(city)
             city = null
             waitForGarbageCollection()
-        then : 'It was collected.'
+        then : 'The city property is gone.'
             cityRef.get() == null
 
-        when : 'We read the composite view for the very first time.'
+        when : 'We now read the composite view for the very first time.'
             var folded = weather.get()
-        then : 'It knows about the change it was notified of, even though nobody read it.'
+        then : 'It knows about the change it was notified of, even though nobody ever read it.'
             folded == new Weather("Graz", 0d, 55, false, "")
     }
 
-    def 'A property joined several times contributes its last item to every one of its combiners.'()
+    def 'Every combiner of a property joined several times gets its newest item after garbage collection.'()
     {
         reportInfo """
-            Joining a property more than once does not change any of this: after the property
-            is collected, every one of its combiners folds in the same last known item.
+            Joining the same property several times changes nothing about any of this.
+            Once the property is garbage collected, every single one of its combiners
+            keeps receiving the same newest item.
         """
-        given : 'A property joined twice, and a second one to trigger recomputations with.'
+        given : 'One property which we join twice, and a second one to recompute the view with.'
             Var<String>  city     = Var.of("Vienna")
             Var<Integer> humidity = Var.of(0)
             Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
@@ -238,62 +250,67 @@ class Composite_View_Memory_Safety_Spec extends Specification
                     .join(city,     (w, c) -> w.withSource("station-" + c))
                     .join(humidity, Weather::withHumidity)
                 )
-        expect : 'Both combiners contributed.'
+        expect : 'Both of the combiners of the city property contributed to the item.'
             weather.get() == new Weather("Vienna", 0d, 0, false, "station-Vienna")
 
-        when : 'We change the doubly joined property and then drop it.'
+        when : 'We change the city, drop our only reference to it, and wait for the garbage collector.'
             city.set("Graz")
             var cityRef = new WeakReference(city)
             city = null
             waitForGarbageCollection()
-        then : 'It was collected.'
+        then : 'The city property is gone.'
             cityRef.get() == null
 
-        when : 'We trigger a recomputation.'
+        when : 'We change the humidity, which makes the view recompute its item.'
             humidity.set(80)
-        then : 'Both combiners folded in the last item, and neither of them fell back to "Vienna".'
+        then : 'Both combiners used "Graz", and neither of them fell back to "Vienna".'
             weather.get() == new Weather("Graz", 0d, 80, false, "station-Graz")
     }
 
-    def 'A nullable property which was emptied before being collected leaves `null` behind.'()
+    def 'A nullable property emptied before the garbage collection contributes `null` afterwards.'()
     {
         reportInfo """
-            The last known item of a collected property may very well be `null`, if that is
-            what the property held when it was last seen. A combiner joined to a nullable
-            property has to be prepared for `null` anyway, so this changes nothing for it.
+            The newest item of a joined property may well be `null`, if `null` is what the
+            property held when the view last looked at it. Combiners joined to a nullable
+            property have to handle `null` anyway, so they simply keep receiving it after
+            the property was garbage collected.
         """
-        given : 'A nullable property, a plain one, and a composite view of both.'
+        given : 'A nullable property, a second property, and a composite view of both.'
             Var<String>  city     = Var.ofNullable(String, "Vienna")
             Var<Integer> humidity = Var.of(55)
             Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
                     .join(city,     (w, c) -> w.withCity(c == null ? "<unknown>" : c))
                     .join(humidity, Weather::withHumidity)
                 )
-        expect : 'The composite view folded the item of the nullable property in.'
+        expect : 'The view folded the item of the nullable property into its own item.'
             weather.get().city() == "Vienna"
 
-        when : 'We empty the nullable property and then drop it.'
+        when : 'We empty the nullable property, drop it, and wait for the garbage collector.'
             city.set(null)
             var cityRef = new WeakReference(city)
             city = null
             waitForGarbageCollection()
-        then : 'It was collected.'
+        then : 'The city property is gone.'
             cityRef.get() == null
 
-        when : 'We trigger a recomputation.'
+        when : 'We change the humidity, which makes the view recompute its item.'
             humidity.set(80)
-        then : 'The combiner received the `null` the property was last holding.'
+        then : 'The combiner received the `null` the property held last, and not "Vienna".'
             weather.get() == new Weather("<unknown>", 0d, 80, false, "")
     }
 
-    def 'A composite view whose joined properties were all collected freezes on its last item.'()
+    def 'A composite view keeps its item after all of its joined properties were garbage collected.'()
     {
         reportInfo """
-            Once every joined property is gone, there is nothing left which could ever change
-            the composite item. The view then simply keeps reporting the item it folded from
-            everything it last knew, instead of breaking or reverting.
+            Once every joined property has been garbage collected, there is nothing left which
+            could ever change the composite item again. The view then simply keeps reporting
+            the item it folded from the newest items it saw, and it keeps reporting that same
+            item no matter how often you read it.
+
+            In particular it does not break, it does not fall back to its seed, and it does not
+            jump back to the items its properties were joined with.
         """
-        given : 'Two plain properties and a composite view of them.'
+        given : 'Two properties and a composite view of them.'
             Var<String>  city     = Var.of("Vienna")
             Var<Integer> humidity = Var.of(55)
             Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
@@ -301,19 +318,19 @@ class Composite_View_Memory_Safety_Spec extends Specification
                     .join(humidity, Weather::withHumidity)
                 )
 
-        when : 'We change both of them and then drop both of them.'
+        when : 'We change both properties, drop both of them, and wait for the garbage collector.'
             city.set("Graz")
             humidity.set(80)
             var refs = [new WeakReference(city), new WeakReference(humidity)]
             city = null
             humidity = null
             waitForGarbageCollection()
-        then : 'Both were collected.'
+        then : 'Both properties are gone.'
             refs.every( it -> it.get() == null )
 
-        and : 'The composite view still reports what it last folded together.'
+        and : 'The view still reports the item it folded from their newest items.'
             weather.get() == new Weather("Graz", 0d, 80, false, "")
-        and : 'And it keeps doing so, no matter how often it is read.'
+        and : 'And it keeps reporting that same item, no matter how often we read it.'
             weather.get() == new Weather("Graz", 0d, 80, false, "")
     }
 

--- a/src/test/groovy/sprouts/Composite_View_Memory_Safety_Spec.groovy
+++ b/src/test/groovy/sprouts/Composite_View_Memory_Safety_Spec.groovy
@@ -1,0 +1,441 @@
+package sprouts
+
+import spock.lang.Narrative
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Title
+
+import java.lang.ref.WeakReference
+
+@Title('Composite View Memory Safety')
+@Narrative('''
+
+    A composite view, created through `Viewable.of(seed, configurator)`, observes every
+    property it was folded from. Sprouts has a firm opinion about which of the references
+    involved in such an observation may be strong and which must be weak, because getting
+    this wrong is the classic source of memory leaks in observer based designs.
+
+    A composite view follows exactly the same policy as any other view:
+
+    * A property references a composite view observing it only **weakly**, so dropping the
+      composite view lets it be collected together with all of the change listeners
+      registered on it.
+    * A composite view references a joined **view or lens strongly**, so that intermediate
+      properties created inline inside the configurator stay alive for as long as they
+      are needed.
+    * A composite view references a joined **plain property weakly**, so that observing
+      your state never keeps that state alive. Should such a property be collected, the
+      composite view keeps folding in its last known item instead of breaking.
+
+    This specification pins down all of these cases by checking which properties actually
+    survive garbage collection, and which do not.
+
+''')
+@Subject([Viewable, Viewable.CompositeBuilder, Val, Var])
+class Composite_View_Memory_Safety_Spec extends Specification
+{
+    static record Weather(
+        String  city,
+        double  temperature,
+        int     humidity,
+        boolean alert,
+        String  source
+    ) {
+        static Weather blank() { return new Weather("", 0d, 0, false, "") }
+        Weather withCity( String city ) { return new Weather(city, this.temperature, this.humidity, this.alert, this.source) }
+        Weather withTemperature( double temperature ) { return new Weather(this.city, temperature, this.humidity, this.alert, this.source) }
+        Weather withHumidity( int humidity ) { return new Weather(this.city, this.temperature, humidity, this.alert, this.source) }
+        Weather withAlert( boolean alert ) { return new Weather(this.city, this.temperature, this.humidity, alert, this.source) }
+        Weather withSource( String source ) { return new Weather(this.city, this.temperature, this.humidity, this.alert, source) }
+    }
+
+
+    def 'A composite view is garbage collected when it is no longer referenced strongly.'()
+    {
+        reportInfo """
+            The properties a composite view is folded from observe it through weak listeners
+            only. So as soon as you stop referencing a composite view, it becomes eligible
+            for garbage collection, and the change listeners it had registered on its joined
+            properties disappear with it.
+        """
+        given : 'Two properties we keep referenced.'
+            var city     = Var.of("Vienna")
+            var humidity = Var.of(55)
+        and : 'A composite view of the two, which we reference weakly as well.'
+            var composite = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+            var compositeRef = new WeakReference(composite)
+        expect : 'The composite view is alive and observing both properties.'
+            city.numberOfChangeListeners() == 1
+            humidity.numberOfChangeListeners() == 1
+
+        when : 'We drop the only strong reference to the composite view.'
+            composite = null
+        and : 'We wait for the garbage collector to do its job.'
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        then : 'The composite view is gone...'
+            compositeRef.get() == null
+        and : '...and so are the change listeners it had registered on the two properties.'
+            city.numberOfChangeListeners() == 0
+            humidity.numberOfChangeListeners() == 0
+    }
+
+    def 'The change listeners of a composite view die together with the view.'()
+    {
+        reportInfo """
+            This is the whole point of a view being weakly referenced: the change listeners
+            you register on a composite view are kept alive by that view and by nothing else.
+            So when you stop referencing the view, your listeners stop being called, even
+            though the properties they ultimately depend on are still very much alive.
+        """
+        given : 'A property we keep referenced.'
+            var city = Var.of("Vienna")
+        and : 'A composite view with a change listener writing into a trace.'
+            var trace = []
+            var composite = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+            composite.onChange(From.ALL, { trace << it.currentValue().orElseNull().city() })
+
+        when : 'We change the joined property while the composite view is alive.'
+            city.set("Graz")
+        then : 'The listener was called.'
+            trace == ["Graz"]
+
+        when : 'We drop the composite view and wait for the garbage collector.'
+            composite = null
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        and : 'We change the joined property again.'
+            city.set("Linz")
+        then : 'The listener is not called anymore, because it died with the view.'
+            trace == ["Graz"]
+        and : 'The property has no change listeners left at all.'
+            city.numberOfChangeListeners() == 0
+    }
+
+    def 'The plain properties a composite view was folded from can be garbage collected.'()
+    {
+        reportInfo """
+            A composite view is a view, and a view never keeps your actual state alive.
+            So the plain properties you joined may be garbage collected even while you are
+            still holding on to the composite view.
+
+            The composite view does not break when that happens: it keeps folding in the
+            last known item of the collected property.
+        """
+        given : 'Two plain properties which we will dereference later.'
+            Var<String>  city     = Var.of("Vienna")
+            Var<Integer> humidity = Var.of(55)
+        and : 'A composite view of the two of them.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+        expect : 'The composite view holds the merged item.'
+            weather.get() == new Weather("Vienna", 0d, 55, false, "")
+
+        when : 'We weakly reference the first property and then drop our strong reference to it.'
+            var cityRef = new WeakReference(city)
+            city = null
+        and : 'We wait for the garbage collector to do its job.'
+            waitForGarbageCollection()
+        then : 'The property was indeed collected, even though the composite view observes it.'
+            cityRef.get() == null
+
+        when : 'We change the property which is still alive.'
+            humidity.set(80)
+        then : """
+            The composite view still works. It folded in the new humidity, and for the city
+            it used the last item it knew about before the property was collected.
+        """
+            weather.get() == new Weather("Vienna", 0d, 80, false, "")
+    }
+
+    def 'A composite view keeps the views and lenses it joined alive.'()
+    {
+        reportInfo """
+            The one kind of joined property a composite view *does* reference strongly is a
+            view or a lens. Those are derived properties which nobody else is going to keep
+            alive for you, which is what lets you create them inline inside the configurator.
+        """
+        given : 'A plain property, and a record property to zoom into.'
+            var city    = Var.of("Vienna")
+            var weather = Var.of(Weather.blank())
+        and : 'A composite view joining a view and a lens which are both created inline.'
+            var nameLength = city.viewAsInt( c -> c.length() )
+            var alertLens  = weather.zoomTo(Weather::alert, Weather::withAlert)
+            var lengthRef = new WeakReference(nameLength)
+            var lensRef   = new WeakReference(alertLens)
+            var composite = Viewable.of(Weather.blank(), it -> it
+                    .join(nameLength, Weather::withHumidity)
+                    .join(alertLens,  Weather::withAlert)
+                )
+        expect : 'The composite view folded both of them in.'
+            composite.get() == new Weather("", 0d, 6, false, "")
+
+        when : 'We drop our own references to the intermediate view and lens.'
+            nameLength = null
+            alertLens = null
+        and : 'We wait for the garbage collector to do its job.'
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        then : 'Both of them are still alive, because the composite view keeps them alive.'
+            lengthRef.get() != null
+            lensRef.get() != null
+
+        when : 'We change the properties they are derived from.'
+            city.set("Sankt Poelten")
+            weather.set(Weather.blank().withAlert(true))
+        then : 'The changes still propagate through the intermediate properties into the composite.'
+            composite.get() == new Weather("", 0d, 13, true, "")
+    }
+
+    def 'A composite view does not keep the source of a joined view alive.'()
+    {
+        reportInfo """
+            A composite view keeps a joined *view* alive, but that view in turn references
+            the plain property it is derived from only weakly. So joining a view does not
+            keep your state alive through the back door.
+        """
+        given : 'A plain property which we will dereference later.'
+            Var<String> city = Var.of("Vienna")
+        and : 'A composite view joining a view derived from that property.'
+            var nameLength = city.viewAsInt( c -> c.length() )
+            var composite = Viewable.of(Weather.blank(), it -> it.join(nameLength, Weather::withHumidity))
+        expect : 'The composite view folded the length of the city name in.'
+            composite.get().humidity() == 6
+
+        when : 'We weakly reference the plain property and drop our strong reference to it.'
+            var cityRef = new WeakReference(city)
+            city = null
+        and : 'We wait for the garbage collector to do its job.'
+            waitForGarbageCollection()
+        then : 'The plain property was collected, even though a joined view was derived from it.'
+            cityRef.get() == null
+        and : 'The intermediate view and the composite view are still alive and consistent.'
+            nameLength.get() == 6
+            composite.get().humidity() == 6
+    }
+
+    def 'A composite view built exclusively from immutable properties does not reference them at all.'()
+    {
+        reportInfo """
+            When every joined property is immutable, then the composite item can never change,
+            and so an immutable property is returned instead of a live view. Such a property
+            has no reason to remember where its item came from, which means the joined
+            properties are not referenced at all and may be collected right away.
+        """
+        given : 'Two immutable properties.'
+            Val<String>  city     = Val.of("Vienna")
+            Val<Integer> humidity = Val.of(55)
+        and : 'A composite view of the two of them.'
+            Viewable<Weather> weather = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+        expect : 'The composite is immutable and holds the merged item.'
+            weather.isImmutable()
+            weather.get() == new Weather("Vienna", 0d, 55, false, "")
+
+        when : 'We weakly reference both immutable properties and drop our strong references.'
+            var cityRef     = new WeakReference(city)
+            var humidityRef = new WeakReference(humidity)
+            city = null
+            humidity = null
+        and : 'We wait for the garbage collector to do its job.'
+            waitForGarbageCollection()
+        then : 'Both of them were collected.'
+            cityRef.get() == null
+            humidityRef.get() == null
+        and : 'The composite still holds the item it computed from them.'
+            weather.get() == new Weather("Vienna", 0d, 55, false, "")
+    }
+
+    def 'A composite view keeps another composite view it was joined to alive.'()
+    {
+        reportInfo """
+            A composite view is a view, so joining one composite view into another one follows
+            the very same rule: the outer composite view references the inner one strongly.
+            This lets you assemble a larger model out of smaller composites which are created
+            inline, without having to store every intermediate step.
+        """
+        given : 'Two plain properties we keep referenced.'
+            var city     = Var.of("Vienna")
+            var humidity = Var.of(55)
+        and : 'An outer composite view joining an inner composite view created inline.'
+            var inner = Viewable.of(Weather.blank(), it -> it
+                    .join(city,     Weather::withCity)
+                    .join(humidity, Weather::withHumidity)
+                )
+            var innerRef = new WeakReference(inner)
+            var outer = Viewable.of(Weather.blank(), it -> it
+                    .join(inner, (w, i) -> w.withCity(i.city()).withHumidity(i.humidity()))
+                )
+        expect : 'The outer composite view merged everything.'
+            outer.get() == new Weather("Vienna", 0d, 55, false, "")
+
+        when : 'We drop our own reference to the inner composite view and await garbage collection.'
+            inner = null
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        and : 'We then change one of the plain properties.'
+            city.set("Graz")
+            var propagated = outer.get()
+        then : 'The inner composite view is still alive, because the outer one keeps it alive.'
+            [innerRef].every( it -> it.get() != null )
+        and : 'So the change propagated through the inner composite view into the outer one.'
+            propagated == new Weather("Graz", 0d, 55, false, "")
+
+        when : 'We now also drop the outer composite view and await garbage collection.'
+            outer = null
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        then : 'Both composite views are gone...'
+            innerRef.get() == null
+        and : '...and the plain properties are not observed by anything anymore.'
+            city.numberOfChangeListeners() == 0
+            humidity.numberOfChangeListeners() == 0
+    }
+
+    def 'The builder of a composite view is not retained by the view it built.'()
+    {
+        reportInfo """
+            The `Viewable.CompositeBuilder` handed to your configurator is a purely temporary
+            value: the composite view copies what it needs out of it and then forgets about it.
+            So a builder which escapes from the configurator does not linger in memory either.
+        """
+        given : 'A property we keep referenced.'
+            var city = Var.of("Vienna")
+        and : 'A composite view whose configurator lets the builder escape.'
+            var escaped = null
+            var composite = Viewable.of(Weather.blank(), { builder ->
+                    var joined = builder.join(city, Weather::withCity)
+                    escaped = joined
+                    return joined
+                })
+            var builderRef = new WeakReference(escaped)
+        expect : 'The composite view works as expected, and the builder is still around.'
+            composite.get().city() == "Vienna"
+            [builderRef].every( it -> it.get() != null )
+
+        when : 'We drop our reference to the escaped builder and await garbage collection.'
+            escaped = null
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        then : 'The builder was collected, even though the composite view it built is still alive.'
+            builderRef.get() == null
+        and : 'The composite view is unaffected.'
+            composite.get().city() == "Vienna"
+
+        when : 'We change the joined property.'
+            city.set("Graz")
+        then : 'The composite view is still perfectly alive.'
+            composite.get().city() == "Graz"
+    }
+
+    def 'Many composite views on the same properties are collected independently of each other.'()
+    {
+        reportInfo """
+            Every composite view registers its own set of weak change listeners on the
+            properties it joined. So composite views built from the same properties do not
+            interfere with each other, and dropping one of them has no effect on the others.
+        """
+        given : 'A property without any listeners.'
+            var city = Var.of("Vienna")
+        expect : 'Initially nothing observes it.'
+            city.numberOfChangeListeners() == 0
+
+        when : 'We create three composite views, of which we keep only one referenced.'
+            var kept = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+            var droppedA = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+            var droppedB = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+            var keptRef = new WeakReference(kept)
+            var refA = new WeakReference(droppedA)
+            var refB = new WeakReference(droppedB)
+        then : 'All three of them observe the property.'
+            city.numberOfChangeListeners() == 3
+
+        when : 'We drop two of them and await garbage collection.'
+            droppedA = null
+            droppedB = null
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        then : 'Exactly the two dropped composite views were collected.'
+            refA.get() == null
+            refB.get() == null
+            keptRef.get() != null
+        and : 'Only the listener of the surviving composite view is left.'
+            city.numberOfChangeListeners() == 1
+
+        when : 'We change the property.'
+            city.set("Graz")
+        then : 'The surviving composite view is updated.'
+            kept.get().city() == "Graz"
+    }
+
+    def 'A chain of composite views is collected from the outside in.'()
+    {
+        reportInfo """
+            Because every composite view keeps the composite views it joined alive, a chain
+            of them can only be collected starting at its outermost end. This mirrors how a
+            chain of ordinary property views behaves.
+        """
+        given : 'A plain property at the root of the chain.'
+            var city = Var.of("Vienna")
+        and : 'A chain of three composite views built on top of each other.'
+            var first  = Viewable.of(Weather.blank(), it -> it.join(city, Weather::withCity))
+            var second = Viewable.of(Weather.blank(), it -> it.join(first, (w, f) -> w.withCity(f.city() + "!")))
+            var third  = Viewable.of(Weather.blank(), it -> it.join(second, (w, s) -> w.withCity(s.city() + "?")))
+        and : 'We weakly reference every link of the chain.'
+            var refs = [new WeakReference(first), new WeakReference(second), new WeakReference(third)]
+        expect : 'The chain produces the expected item.'
+            third.get().city() == "Vienna!?"
+        and : 'Every link of the chain is alive.'
+            refs.every( it -> it.get() != null )
+
+        when : 'We drop the two inner links of the chain and await garbage collection.'
+            first = null
+            second = null
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        and : 'We read the item of the outermost link of the chain.'
+            var stillFolding = third.get().city()
+        then : 'Every link is still alive, because the outermost one keeps the chain alive.'
+            refs.every( it -> it.get() != null )
+        and : 'So the chain still works.'
+            stillFolding == "Vienna!?"
+
+        when : 'We now also drop the outermost link and await garbage collection.'
+            third = null
+            waitForGarbageCollection()
+            Thread.sleep(500)
+            waitForGarbageCollection()
+        then : 'The whole chain was collected.'
+            refs.every( it -> it.get() == null )
+        and : 'The plain property at the root is not observed anymore.'
+            city.numberOfChangeListeners() == 0
+    }
+
+    /**
+     * This method guarantees that garbage collection is
+     * done unlike <code>{@link System#gc()}</code>
+     */
+    static void waitForGarbageCollection() {
+        Object obj = new Object()
+        WeakReference ref = new WeakReference<>(obj)
+        obj = null
+        while ( ref.get() != null ) {
+            System.gc()
+        }
+    }
+}


### PR DESCRIPTION

This is a feature request with the following initial API draft
illustrated through an example snippet:

```java

// Composite model:
@With
record R(int a, String b, byte c, double e) {
    public R() {this(0,"", (byte) 0, 0.0);}
}

// properties or property views:
var p1 = Var.of(42);
var p2 = p1.viewAsString();
var p3 = Var.of((byte)7);
var p4 = p2.viewAs(Double.class, s -> s.length() / 3.14);

// Composite viewable draining properties reactively:
var composite = Viewable.of(new R(), it -> it
        .join(p1, R::withA)
        .join(p2, R::withB)
        .join(p3, R::withC)
        .join(p4, R::withD)
    );

// composite is of type 'Viewable<R>'
// 'it' is of type 'Viewable.CompositeBuilder'

```
